### PR TITLE
registerValidator send array of entries

### DIFF
--- a/apis/builder/validators.yaml
+++ b/apis/builder/validators.yaml
@@ -18,7 +18,9 @@ post:
     content:
       application/json:
         schema:
-            $ref: "../../builder-oapi.yaml#/components/schemas/SignedValidatorRegistration"
+          type: array
+          items:
+              $ref: "../../builder-oapi.yaml#/components/schemas/SignedValidatorRegistration"
   responses:
     "200":
       description: Success response.


### PR DESCRIPTION
Update `registerValidator` to accept an array of entries (in line with the beacon-API: https://github.com/ethereum/beacon-APIs/blob/master/apis/validator/register_validator.yaml)