### PR TITLE
bid: change pubkey and include relay_pubkey

### DIFF
--- a/types/bellatrix/bid.yaml
+++ b/types/bellatrix/bid.yaml
@@ -9,9 +9,12 @@ Bellatrix:
       value:
         $ref: "../../beacon-apis/types/primitive.yaml#/Uint256"
         description: "Payment in wei that will be paid to the `fee_recipient` account."
-      pubkey:
+      builder_pubkey:
         $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
         description: "BLS public key of builder."
+      relay_pubkey:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
+        description: "BLS public key of relay."
 
   SignedBuilderBid:
     type: object
@@ -21,3 +24,4 @@ Bellatrix:
         $ref: "#/Bellatrix/BuilderBid"
       signature:
         $ref: "../../beacon-apis/types/primitive.yaml#/Signature"
+        description: "BLS signature of relay over `message`"


### PR DESCRIPTION
Let's add both the builder and relay pk into the `BuilderBid`. This is useful for many cases, including not only relying on the relay pk pre-configured in mev-boost at startup.

