### PR TITLE
Clarify `fork_version` and `genesis_validator_root` for  domain

### DIFF
--- a/specs/builder.md
+++ b/specs/builder.md
@@ -135,7 +135,8 @@ There are two types of data to sign over in the Builder API:
   and use the domain specified for beacon block proposals.
 * Builder API messages, e.g. validator registration, which should compute the
   signing root using [`compute_signing_root`][compute-root] with domain given by
-  `compute_domain(DOMAIN_APPLICATION_BUILDER)`.
+  `compute_domain(DOMAIN_APPLICATION_BUILDER)` with inputs 
+  `fork_version=GENESIS_FORK_VERSION` and `genesis_validators_root=Root()`.
 As `compute_signing_root` takes `SSZObject` as input, client software should
 convert in-protocol messages to their SSZ representation to compute the signing
 root and Builder API messages to the SSZ representations defined


### PR DESCRIPTION
Further clarify what `fork_version` and `genesis_validator_root` should be for  `compute_domain(DOMAIN_APPLICATION_BUILDER)`. It was a little confusing at first until reading the spec code