### PR TITLE
Explicitly mention `signed_builder_bid` under signing

### DIFF
--- a/specs/builder.md
+++ b/specs/builder.md
@@ -133,7 +133,7 @@ There are two types of data to sign over in the Builder API:
 * In-protocol messages, e.g. [`BlindedBeaconBlock`](#blindedbeaconblock), which
   should compute the signing root using [`compute_signing_root`][compute-root]
   and use the domain specified for beacon block proposals.
-* Builder API messages, e.g. validator registration, which should compute the
+* Builder API messages, e.g. validator registration and signed builder bid, which should compute the
   signing root using [`compute_signing_root`][compute-root] with domain given by
   `compute_domain(DOMAIN_APPLICATION_BUILDER, fork_version=None, genesis_validators_root=None)`.
 As `compute_signing_root` takes `SSZObject` as input, client software should


### PR DESCRIPTION
Although it's "covered" under builder API messages, I think it's better to explicitly call it out. I've seen two occurrences where implementations mistakenly use the non-genesis fork version and non-zeros genesis validator root