### PR TITLE
Deprecate Builder specs in lights of Flashbots adopting OFAC sanctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ In this repository:
 * [Honest validator specification][validator-spec]
 
 
-### Builder API is currently deprecated
+### ⚠️⚠️⚠️ Builder API is currently deprecated ⚠️⚠️⚠️
 
 In lights of current events, and in particular in lights of MEV-Boost adopting OFAC sanctions, the Builder API is momentairly deprecated.
-Client Teams **MUST** not implement and expose the Builder API until the situation stabilises. **NOTE: Builder API is only momentairly deprecated, and could eventually be re-considered if the situation changes.**
+Client Teams **MUST** not implement and expose the Builder API until the situation stabilises. **NOTE: Builder API is only momentairly deprecated, and will eventually be re-considered if the situation changes.**
 
 ### Why?
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ In this repository:
 * [Builder specification][builder-spec]
 * [Honest validator specification][validator-spec]
 
+
+### Builder API is currently deprecated
+
+In lights of current events, and in particular in lights of MEV-Boost adopting OFAC sanctions, the Builder API is momentairly deprecated.
+Client Teams **MUST** not implement and expose the Builder API until the situation stabilises. **NOTE: Builder API is only momentairly deprecated, and could eventually be re-considered if the situation changes.**
+
 ### Why?
 
 Block building is a specialized activity that requires high fixed costs to be

--- a/specs/builder.md
+++ b/specs/builder.md
@@ -148,6 +148,10 @@ repository. A rendered version can be viewed at
 https://ethereum.github.io/builder-specs/.
 
 
+## Deprecation
+
+As MEV-Boost is adhering to OFAC sanctions, the Builder API is deprecated and should not be used, as it allows censorship code in the base layer.
+
 [consensus-specs]: https://github.com/ethereum/consensus-specs
 [bls]: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#bls-signatures
 [compute-root]: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#compute_signing_root

--- a/specs/builder.md
+++ b/specs/builder.md
@@ -150,7 +150,7 @@ https://ethereum.github.io/builder-specs/.
 
 ## Deprecation
 
-As MEV-Boost is adhering to OFAC sanctions, the Builder API is deprecated and should not be used, as it allows censorship code in the base layer.
+As MEV-Boost is adhering to OFAC sanctions, the Builder API is deprecated and should not be implemented by consensus client teams. In light of the fact that it allows censorship code in the base layer.
 
 [consensus-specs]: https://github.com/ethereum/consensus-specs
 [bls]: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#bls-signatures

--- a/specs/validator.md
+++ b/specs/validator.md
@@ -157,6 +157,10 @@ Concretely, honest validators **MUST** wait until the transition has been finali
 they can start querying the external builder network. See [EIP-3675](eip-3675) for further details about the transition
 process itself.
 
+## Deprecation
+
+As MEV-Boost is adhering to OFAC sanctions, the Builder API is deprecated and should not be implemented by consensus client teams. In light of the fact that it allows censorship code in the base layer.
+
 [builder-spec]: ./builder.md
 [builder-spec-apis]: ./builder.md#endpoints
 [register-validator-with-builder]: https://ethereum.github.io/builder-specs/#/Builder/registerValidator


### PR DESCRIPTION
## Rationale

Flashbots has been found to censor transactions in their bundles, and It is just a matter of time for when they are going to do the same in MEV-Boost. I believe, it is an attack on Ethereum and Decentralization as a whole and needs to be tackled somehow. this is just the first shot.

## Additions

This PR adds a couple of deprecation notes on the builder specs and momentarily deprecates it. flashbots can use their own closed source code to do this but I believe that the Ethereum community should not let users use MEV-Boost. **Note: this deprecation is meant to be momentary, and will by no mean extend for too much time.**