### PR TITLE
[wip] SSZ encoding for getHeader and getPayload

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -35,7 +35,7 @@ rules:
     recommended: true
     severity: error
     message: "{{description}}: {{error}}"
-    given: $.paths.[*].requestBody.content[?(@property.indexOf('json') === -1)]^
+    given: $.paths.[*].requestBody.content[0(@property.indexOf('json') === -1)]^
     then:
       function: falsy
 

--- a/apis/builder/blinded_blocks.yaml
+++ b/apis/builder/blinded_blocks.yaml
@@ -9,6 +9,10 @@ post:
 
     If the builder is not able to unblind the corresponding
     `ExecutionPayloadHeader`, it must error.
+
+    The request body can be encoded as JSON (application/json) or SSZ (application/octet-stream).
+    Note: SSZ support can be determined by requesting an SSZ encoded response in the `getHeader`
+    request.
   tags:
     - Builder
   requestBody:
@@ -22,6 +26,9 @@ post:
         examples:
           bellatrix:
             $ref: "../../builder-oapi.yaml#/components/examples/Bellatrix.SignedBlindedBeaconBlock"
+      application/octet-stream:
+        schema:
+          title: SignedBlindedBeaconBlock
 
   responses:
     "200":
@@ -42,6 +49,12 @@ post:
           examples:
             bellatrix:
               $ref: "../../builder-oapi.yaml#/components/examples/Bellatrix.ExecutionPayload"
+        application/octet-stream:
+          schema:
+            title: SubmitBlindedBlockResponse
+            type: string
+            format: binary
+            description: SSZ encoded SubmitBlindedBlockResponse
     "400":
       description: Error response.
       content:

--- a/apis/builder/header.yaml
+++ b/apis/builder/header.yaml
@@ -18,6 +18,9 @@ get:
     builder must return a header that moves `gas_limit` the maximum amount
     allowed under the rules of consensus (currently `parent.gas_limit +/-
     parent.gas_limit / 1024`).
+
+    A SSZ encoded response can be requested using the `Accept` request header:
+    `Accept: application/octet-stream`.
   tags:
     - Builder
   parameters:
@@ -39,6 +42,13 @@ get:
       description: The validator's BLS public key.
       schema:
         $ref: "../../builder-oapi.yaml#/components/schemas/Pubkey"
+    - name: accept
+      in: header
+      description: "requested encoding: `application/octet-stream` (SSZ), `application/json`, or a combination."
+      example: "application/octet-stream;q=1,application/json;q=0.9"
+      required: false
+      schema:
+        type: string
   responses:
     "200":
       description: Success response.
@@ -58,6 +68,13 @@ get:
           examples:
             bellatrix:
               $ref: "../../builder-oapi.yaml#/components/examples/Bellatrix.SignedBuilderBid"
+        application/octet-stream:
+          schema:
+            title: GetHeaderResponse
+            type: string
+            format: binary
+            description: SSZ encoded GetHeaderResponse
+
     "204":
       description: No header is available.
     "400":


### PR DESCRIPTION
Allows SSZ encoded payloads for getHeader and getPayload: https://github.com/ethereum/builder-specs/issues/53

This PR adds:
1. `getHeader` header: `Accept`
2. `getHeader` response encoding: `application/octet-stream`
3. `getPayload` request and response encoding: `application/octet-stream`
