### PR TITLE
Update block's `blob_kzg_commitments` size limit

### DIFF
--- a/specs/deneb/builder.md
+++ b/specs/deneb/builder.md
@@ -115,5 +115,5 @@ class BlindedBeaconBlockBody(Container):
     sync_aggregate: SyncAggregate
     execution_payload_header: ExecutionPayloadHeader  # [Modified in Deneb]
     bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
-    blob_kzg_commitments: List[KZGCommitment, MAX_BLOBS_PER_BLOCK]  # [New in Deneb]
+    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]  # [New in Deneb]
 ```


### PR DESCRIPTION
Small change to update block's `blob_kzg_commitments` size limit.
Consensus spec PR merged: https://github.com/ethereum/consensus-specs/pull/3338. 