### PR TITLE
Fix incorrect field name in Deneb `BuilderBid` type

### DIFF
--- a/examples/deneb/signed_builder_bid.json
+++ b/examples/deneb/signed_builder_bid.json
@@ -22,9 +22,9 @@
           "withdrawals_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
         },
         "blinded_blobs_bundle": {
-          "blob_roots": ["0x24564723180fcb3d994104538d351c8dcbde12d541676bb736cf678018ca4739"],
           "commitments": ["0x8dab030c51e16e84be9caab84ee3d0b8bbec1db4a0e4de76439da8424d9b957370a10a78851f97e4b54d2ce1ab0d686f"],
-          "proofs": ["0xb4021b0de10f743893d4f71e1bf830c019e832958efd6795baf2f83b8699a9eccc5dc99015d8d4d8ec370d0cc333c06a"]
+          "proofs": ["0xb4021b0de10f743893d4f71e1bf830c019e832958efd6795baf2f83b8699a9eccc5dc99015d8d4d8ec370d0cc333c06a"],
+          "blob_roots": ["0x24564723180fcb3d994104538d351c8dcbde12d541676bb736cf678018ca4739"]
         },
         "value": "1",
         "pubkey": "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"

--- a/specs/deneb/builder.md
+++ b/specs/deneb/builder.md
@@ -89,7 +89,7 @@ Note: `SignedBuilderBid` is updated indirectly.
 ```python
 class BuilderBid(Container):
     header: ExecutionPayloadHeader # [Modified in Deneb]
-    blinded_blobs: BlindedBlobsBundle  # [New in Deneb]
+    blinded_blobs_bundle: BlindedBlobsBundle  # [New in Deneb]
     value: uint256
     pubkey: BLSPubkey
 ```

--- a/types/deneb/bid.yaml
+++ b/types/deneb/bid.yaml
@@ -7,7 +7,7 @@ Deneb:
           header:
             $ref: "../../beacon-apis/types/deneb/execution_payload.yaml#/Deneb/ExecutionPayloadHeader"
             description: "`ExecutionPayloadHeader` to use in block proposal."
-          blinded_blobs:
+          blinded_blobs_bundle:
             $ref: "./blobs_bundle.yaml#/Deneb/BlindedBlobsBundle"
             description: "`BlindedBlobsBundle` to use in block proposal."
       - $ref: '../bellatrix/bid.yaml#/Bellatrix/BuilderBidCommon'


### PR DESCRIPTION
I've just noticed that the field names in the `BuilderBid` schema doesn't match the `SignedBuilderBid` example JSON:

https://github.com/ethereum/builder-specs/blob/0d039df6cbe8af9ff16a1546281064d41638b5e6/examples/deneb/signed_builder_bid.json#L24-L28

- I've updated the field name to `blinded_blobs_bundle` to match the example. (I think this name also reflects the structure better)
- Fixed the ordering of the fields in the example to match the schema, i.e. `blob_roots` comes last in `blinded_blobs_bundle`