### PR TITLE
RFC: Use `MAX_BLOB_COMMITMENTS_PER_BLOCK` as max length  for BlindedBlobsBundle SSZ lists

### DIFF
--- a/specs/deneb/builder.md
+++ b/specs/deneb/builder.md
@@ -33,9 +33,9 @@ This is the modification of the builder specification accompanying the Deneb upg
 
 ```python
 class BlindedBlobsBundle(Container):
-    commitments: List[KZGCommitment, MAX_BLOBS_PER_BLOCK]
-    proofs: List[KZGProof, MAX_BLOBS_PER_BLOCK]
-    blob_roots: List[Root, MAX_BLOBS_PER_BLOCK]
+    commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    blob_roots: List[Root, MAX_BLOB_COMMITMENTS_PER_BLOCK]
 ```
 
 #### `BlindedBlobSidecar`


### PR DESCRIPTION
## Context 

In the below consensus PR, `MAX_BLOB_COMMITMENTS_PER_BLOCK` was introduced and used in the SSZ specification for `blob_kzg_commitments` in the deneb beacon block:
- https://github.com/ethereum/consensus-specs/pull/3338

The SSZ representation of KZG blobs commitments are currently different in `BeaconBlockBody` and `BlindedBlobBundle`:

[`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/ef434e87165e9a4c82a99f54ffd4974ae113f732/specs/deneb/beacon-chain.md?plain=1#L100-L116):
```python
class BeaconBlockBody(Container):
    ...
    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]  # [New in Deneb:EIP4844]
```

[`BlindedBlobsBundle`](https://github.com/ethereum/builder-specs/blob/2b7977f5f8fdebde3097097492ba2d1298071d6e/specs/deneb/builder.md?plain=1#L35-L38):
```python
 class BlindedBlobsBundle(Container): 
     commitments: List[KZGCommitment, MAX_BLOBS_PER_BLOCK] 
     proofs: List[KZGProof, MAX_BLOBS_PER_BLOCK] 
     blob_roots: List[Root, MAX_BLOBS_PER_BLOCK] 
```

I'm interested in hearing people's thought about whether `MAX_BLOBS_PER_BLOCK` or `MAX_BLOB_COMMITMENTS_PER_BLOCK` should be used in the `BlindedBlobsBundle` SSZ specification. AFAIK this has no impact on serialisation or deserialisation, but will be used in computing the signing root for the `BuilderBid`.

I think we'd be okay either way, as this tree hash root isn't stored anywhere and only used for bid signatures, which means it's short lived. Using `MAX_BLOB_COMMITMENTS_PER_BLOCK` for max length gives us consistency with the beacon block representation, which means in some languages we could reuse the same type (not necessary important I guess?). On the other hand, using `MAX_BLOBS_PER_BLOCK` means it's probably more consistent with the rest of the API specs - `maxItems: 6` is specified for all blob related lists, including `blobs_sidecars`. 

I don't have a strong opinion here, keen to hear people's thoughts!

