### PR TITLE
Update Deneb for `v1.4.0-beta.4`

### DIFF
--- a/apis/builder/blinded_blocks.yaml
+++ b/apis/builder/blinded_blocks.yaml
@@ -10,7 +10,7 @@ post:
     must return an error response (400) with a description of the validation
     failure.
 
-    After Deneb, this endpoint will additionally accept `SignedBlindedBlobSidecars`, and return
+    After Deneb, this endpoint will additionally accept `BlindedBlobSidecars`, and return
     with additional unblinded blobs in response.
   tags:
     - Builder

--- a/specs/deneb/builder.md
+++ b/specs/deneb/builder.md
@@ -10,7 +10,6 @@
   - [New containers](#new-containers)
     - [`BlindedBlobsBundle`](#blindedblobsbundle)
     - [`BlindedBlobSidecar`](#blindedblobsidecar)
-    - [`SignedBlindedBlobSidecar`](#signedblindedblobsidecar)
     - [`SignedBlindedBlockContents`](#signedblindedblockcontents)
     - [`BlobsBundle`](#blobsbundle)
     - [`ExecutionPayloadAndBlobsBundle`](#executionpayloadandblobsbundle)
@@ -42,22 +41,13 @@ class BlindedBlobsBundle(Container):
 
 ```python
 class BlindedBlobSidecar(Container):
-    block_root: Root
     index: BlobIndex
-    slot: Slot
-    block_parent_root: Root
-    proposer_index: ValidatorIndex
     blob_root: Root
     kzg_commitment: KZGCommitment
     kzg_proof: KZGProof
-```
-
-#### `SignedBlindedBlobSidecar`
-
-```python
-class SignedBlindedBlobSidecar(Container):
-    message: BlindedBlobSidecar
-    signature: BLSSignature
+    signed_block_header: SignedBeaconBlockHeader
+    kzg_commitment_inclusion_proof*:
+      array[KZG_COMMITMENT_INCLUSION_PROOF_DEPTH, Eth2Digest]
 ```
 
 #### `SignedBlindedBlockContents`
@@ -65,7 +55,7 @@ class SignedBlindedBlobSidecar(Container):
 ```python
 class SignedBlindedBlockContents(Container):
     signed_blinded_block: SignedBlindedBeaconBlock
-    signed_blinded_blob_sidecars: List[SignedBlindedBlobSidecar, MAX_BLOBS_PER_BLOCK]
+    blinded_blob_sidecars: List[BlindedBlobSidecar, MAX_BLOBS_PER_BLOCK]
 ```
 
 #### `BlobsBundle`


### PR DESCRIPTION
`BlindedBlobSidecar` are no longer signed, but instead are linked with signed block via merkle proof. Renamed `signed_blinded_blob_sidecars` in `SignedBlindedBlockContents` envelopes to match the new types.

- https://github.com/ethereum/consensus-specs/pull/3531
- https://github.com/ethereum/beacon-APIs/pull/370