### PR TITLE
Update builder.md to replace `SignedBlobSidecar` with `BlobSidecar`

### DIFF
--- a/specs/deneb/builder.md
+++ b/specs/deneb/builder.md
@@ -96,5 +96,5 @@ in the `SignedBuilderBid`.
 #### Blinded block processing
 
 Relays verify signed blinded beacon blocks as before, with the additional requirement
-that they must construct `SignedBlobSidecar` objects with the KZG commitment inclusion
+that they must construct `BlobSidecar` objects with the KZG commitment inclusion
 proof before gossiping the blobs alongside the unblinded block.


### PR DESCRIPTION
Update builder.md to replace `SignedBlobSidecar` with `BlobSidecar` as they are no longer signed.

reference: https://github.com/ethereum/consensus-specs/pull/3531