### PR TITLE
Add required properties to object types

### DIFF
--- a/apis/builder/blinded_blocks.yaml
+++ b/apis/builder/blinded_blocks.yaml
@@ -46,6 +46,7 @@ post:
           schema:
             title: SubmitBlindedBlockResponse
             type: object
+            required: [version, data]
             properties:
               version:
                 type: string

--- a/apis/builder/header.yaml
+++ b/apis/builder/header.yaml
@@ -40,6 +40,7 @@ get:
           schema:
             title: GetHeaderResponse
             type: object
+            required: [version, data]
             properties:
               version:
                 type: string

--- a/types/bellatrix/bid.yaml
+++ b/types/bellatrix/bid.yaml
@@ -1,6 +1,7 @@
 Bellatrix:
   BuilderBidCommon:
     type: object
+    required: [value, pubkey]
     properties:
       value:
         $ref: "../../beacon-apis/types/primitive.yaml#/Uint256"
@@ -13,6 +14,7 @@ Bellatrix:
     description: "The `BuilderBid` object from the Builder API Bellatrix spec."
     allOf:
       - type: object
+        required: [header]
         properties:
           header:
             $ref: "../../beacon-apis/types/bellatrix/execution_payload.yaml#/Bellatrix/ExecutionPayloadHeader"
@@ -22,6 +24,7 @@ Bellatrix:
   SignedBuilderBid:
     type: object
     description: "The `SignedBuilderBid` object from the Builder API spec."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Bellatrix/BuilderBid"

--- a/types/capella/bid.yaml
+++ b/types/capella/bid.yaml
@@ -3,6 +3,7 @@ Capella:
     description: "The `BuilderBid` object from the Builder API Capella spec."
     allOf:
       - type: object
+        required: [header]
         properties:
           header:
             $ref: "../../beacon-apis/types/capella/execution_payload.yaml#/Capella/ExecutionPayloadHeader"
@@ -12,6 +13,7 @@ Capella:
   SignedBuilderBid:
     type: object
     description: "The `SignedBuilderBid` object from the Builder API spec."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Capella/BuilderBid"

--- a/types/deneb/bid.yaml
+++ b/types/deneb/bid.yaml
@@ -3,6 +3,7 @@ Deneb:
     description: "The `BuilderBid` object from the Builder API Deneb spec."
     allOf:
       - type: object
+        required: [header, blob_kzg_commitments]
         properties:
           header:
             $ref: "../../beacon-apis/types/deneb/execution_payload.yaml#/Deneb/ExecutionPayloadHeader"
@@ -19,6 +20,7 @@ Deneb:
   SignedBuilderBid:
     type: object
     description: "The `SignedBuilderBid` object from the Builder API spec."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Deneb/BuilderBid"

--- a/types/deneb/blobs_bundle.yaml
+++ b/types/deneb/blobs_bundle.yaml
@@ -2,6 +2,7 @@ Deneb:
   BlobsBundle:
     type: object
     description: "The `BlobsBundle` object from the CL Deneb spec"
+    required: [blobs, commitments, proofs]
     properties:
       blobs:
         type: array

--- a/types/deneb/execution_payload_and_blobs_bundle.yaml
+++ b/types/deneb/execution_payload_and_blobs_bundle.yaml
@@ -2,6 +2,7 @@ Deneb:
   ExecutionPayloadAndBlobsBundle:
     type: object
     description: "A wrapper object containing the ExecutionPayload and the BlobsBundle"
+    required: [execution_payload, blobs_bundle]
     properties:
       execution_payload:
         $ref: '../../beacon-apis/types/deneb/execution_payload.yaml#/Deneb/ExecutionPayload'

--- a/types/http.yaml
+++ b/types/http.yaml
@@ -4,6 +4,7 @@ InternalError:
     application/json:
       schema:
         type: object
+        required: [code, message]
         properties:
           code:
             description: "Either specific error code in case of invalid request or http status code"


### PR DESCRIPTION
- See https://github.com/ethereum/beacon-APIs/pull/399 for motivation / rationale

Note that there is no need to add required field to request bodies as this is already set correctly