### PR TITLE
Replace oneOf with anyOf in openapi schemas

### DIFF
--- a/apis/builder/blinded_blocks.yaml
+++ b/apis/builder/blinded_blocks.yaml
@@ -26,7 +26,7 @@ post:
     content:
       application/json:
         schema:
-          oneOf:
+          anyOf:
             - $ref: "../../builder-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
             - $ref: "../../builder-oapi.yaml#/components/schemas/Capella.SignedBlindedBeaconBlock"
             - $ref: "../../builder-oapi.yaml#/components/schemas/Deneb.SignedBlindedBeaconBlock"
@@ -53,7 +53,7 @@ post:
                 enum: [ bellatrix, capella, deneb ]
                 example: "bellatrix"
               data:
-                oneOf:
+                anyOf:
                   - $ref: "../../builder-oapi.yaml#/components/schemas/Bellatrix.ExecutionPayload"
                   - $ref: "../../builder-oapi.yaml#/components/schemas/Capella.ExecutionPayload"
                   - $ref: "../../builder-oapi.yaml#/components/schemas/Deneb.ExecutionPayloadAndBlobsBundle"

--- a/apis/builder/header.yaml
+++ b/apis/builder/header.yaml
@@ -47,7 +47,7 @@ get:
                 enum: [ bellatrix, capella, deneb ]
                 example: "bellatrix"
               data:
-                oneOf:
+                anyOf:
                  - $ref: "../../builder-oapi.yaml#/components/schemas/Bellatrix.SignedBuilderBid"
                  - $ref: "../../builder-oapi.yaml#/components/schemas/Capella.SignedBuilderBid"
                  - $ref: "../../builder-oapi.yaml#/components/schemas/Deneb.SignedBuilderBid"


### PR DESCRIPTION
Current openapi spec is invalid, see [validation result](https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fethereum.github.io%2Fbuilder-specs%2Freleases%2Fv0.4.0%2Fbuilder-oapi.json).

See https://github.com/ethereum/beacon-APIs/pull/421 for more rational.