### PR TITLE
Add consensus version header to the `GET builder/header` request

### DIFF
--- a/apis/builder/header.yaml
+++ b/apis/builder/header.yaml
@@ -32,6 +32,12 @@ get:
       description: The validator's BLS public key.
       schema:
         $ref: "../../builder-oapi.yaml#/components/schemas/Pubkey"
+    - in: header
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/ConsensusVersion"
+      required: false
+      name: Eth-Consensus-Version
+      description: "The active consensus version to which the slot belongs."
   responses:
     "200":
       description: Success response.


### PR DESCRIPTION
Since `GET builder/header` now supports SSZ we need to know the active consensus version in order to decode the SSZ response. `commit-boost` (and maybe `mev-boost`?) don't have the functionality to calculate the consensus version based on a given slot. Furthermore I'd argue the beacon node is the more logical place to do such a calculation. I propose that we make BN's fully responsible for this calculation by adding the consensus version to the `GET builder/header` request header 