### PR TITLE
Clarify that version header is only required with SSZ encoding

### DIFF
--- a/apis/builder/blinded_blocks.yaml
+++ b/apis/builder/blinded_blocks.yaml
@@ -22,7 +22,7 @@ post:
         $ref: "../../builder-oapi.yaml#/components/schemas/ConsensusVersion"
       required: false
       name: Eth-Consensus-Version
-      description: "Version of the block being submitted"
+      description: "The active consensus version to which the block being submitted belongs. Required if request is SSZ encoded."
   requestBody:
     description: A `SignedBlindedBeaconBlock`.
     required: true

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -108,6 +108,7 @@ components:
   headers:
     Eth-Consensus-Version:
       $ref: "./beacon-apis/beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version"
+      description: "The active consensus version to which the data belongs. Required if response is SSZ encoded."
       schema:
         $ref: "#/components/schemas/ConsensusVersion"
 


### PR DESCRIPTION
While the schema already notes that the `Eth-Consensus-Version` header is not required, we should clarify that it is actually required for requests / responses that are SSZ encoded.

This formalizes it more on the spec itself as https://github.com/ethereum/builder-specs/pull/104 mostly just highlighted that in the PR description.
> Adds Eth-Consensus-Version to responses, only required if response body is SSZ encoded but preferably should be added to all responses eventually

The current header description also contradicts with the schema as it is inherited from the beacon-api and notes that it is required for all responses which is not correct for the builder-api spec yet.
> The active consensus version to which the data belongs. Required in response so client can deserialize returned json or ssz data more effectively.

So we need to override this description on the builder-api spec for now.

Also rephrases the header description slightly to match more recent changes done to beacon-api in https://github.com/ethereum/beacon-APIs/pull/470.