### PR TITLE
Unstaked Builder API

### DIFF
--- a/apis/builder/beacon_block.yaml
+++ b/apis/builder/beacon_block.yaml
@@ -1,0 +1,50 @@
+post:
+  operationId: "submitSignedBeaconBlock"
+  summary: Submit a signed beacon block with the execution payload bid.
+  description: |
+    Submits a `SignedBeaconBlock` to the builder, binding the proposer to the block. 
+
+    A success response (200) indicates that the signed beacon block was
+    valid. If the signed beacon block was invalid, then the builder
+    must return an error response (400) with a description of the validation
+    failure.
+  tags:
+    - Builder
+  parameters:
+    - in: header
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/ConsensusVersion"
+      required: false
+      name: Eth-Consensus-Version
+      description: "The active consensus version to which the block being submitted belongs. Required if request is SSZ encoded."
+  requestBody:
+    description: A `SignedBeaconBlock`.
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [data]
+          properties:
+            data:
+              $ref: "../../beacon-apis/types/gloas/block.yaml#/Gloas/SignedBeaconBlock"
+              description: "The signed beacon block."
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized `SignedBeaconBlock` bytes. Use content type header to indicate that SSZ data is contained in the request body."
+  responses:
+    "202":
+      description: Success response.
+    "400":
+      description: Error response.
+      content:
+        application/json:
+          schema:
+            $ref: "../../builder-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Invalid signed beacon block: missing signature"
+    "415":
+      $ref: "../../builder-oapi.yaml#/components/responses/UnsupportedMediaType"
+    "500":
+      $ref: "../../builder-oapi.yaml#/components/responses/InternalError"

--- a/apis/builder/block_and_envelope.yaml
+++ b/apis/builder/block_and_envelope.yaml
@@ -1,0 +1,82 @@
+post:
+  operationId: "submitBlockAndEnvelope"
+  summary: Submit a signed beacon block and blinded execution payload envelope.
+  description: |
+    Submits a `SignedBeaconBlock` and a `SignedBlindedExecutionPayloadEnvelope` to an
+    unstaked builder, binding the proposer to the block.
+
+    The validator sends the following:
+    - A `SignedBeaconBlock` containing the `ExecutionPayloadBid` from the builder
+    - A `SignedBlindedExecutionPayloadEnvelope` with:
+      - `beacon_block_root`: The root of the signed beacon block
+      - `payload_root`: The root of the execution payload
+      - `execution_requests_root`: The root of the execution requests
+      - `blob_kzg_commitments_root`: The root of the blob KZG commitments
+      - `builder_index`: Set to `BUILDER_INDEX_SELF_BUILD`
+      - `slot`: The slot of the block
+      - `state_root`: The post-state root
+
+    A success response (202) indicates that the submission was valid. The builder will:
+    1. Validate the beacon block and blinded envelope
+    2. Construct the full `SignedExecutionPayloadEnvelope` by unblinding the payload
+    3. Broadcast the `SignedExecutionPayloadEnvelope` to the PTC committee
+
+    If the submission is invalid, then the builder MUST return an error response (400)
+    with a description of the validation failure.
+
+    This API is applicable from Glamsterdam fork onwards for unstaked builders.
+  tags:
+    - Builder
+  parameters:
+    - in: header
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/ConsensusVersion"
+      required: false
+      name: Eth-Consensus-Version
+      description: "The active consensus version to which the block being submitted belongs. Required if request is SSZ encoded."
+  requestBody:
+    description: A `SignedBeaconBlock` and `SignedBlindedExecutionPayloadEnvelope`.
+    required: true
+    content:
+      application/json:
+        schema:
+          title: BlockAndBlindedEnvelopeRequest
+          type: object
+          required: [signed_beacon_block, signed_blinded_envelope]
+          properties:
+            signed_beacon_block:
+              $ref: "../../beacon-apis/types/gloas/block.yaml#/Gloas/SignedBeaconBlock"
+              description: "The signed beacon block containing the ExecutionPayloadBid."
+            signed_blinded_envelope:
+              $ref: "../../types/gloas/blinded_envelope.yaml#/Gloas/SignedBlindedExecutionPayloadEnvelope"
+              description: "The signed blinded execution payload envelope."
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized `BlockAndBlindedEnvelope` bytes. Use content type header to indicate that SSZ data is contained in the request body."
+  responses:
+    "202":
+      description: Success response. The builder will construct and broadcast the SignedExecutionPayloadEnvelope to the PTC committee.
+    "400":
+      description: Error response.
+      content:
+        application/json:
+          schema:
+            $ref: "../../builder-oapi.yaml#/components/schemas/ErrorMessage"
+          examples:
+            InvalidBlock:
+              value:
+                code: 400
+                message: "Invalid block: missing signature"
+            InvalidEnvelope:
+              value:
+                code: 400
+                message: "Invalid envelope: beacon_block_root mismatch"
+            BidMismatch:
+              value:
+                code: 400
+                message: "Bid mismatch: ExecutionPayloadBid does not match provided bid"
+    "415":
+      $ref: "../../builder-oapi.yaml#/components/responses/UnsupportedMediaType"
+    "500":
+      $ref: "../../builder-oapi.yaml#/components/responses/InternalError"
+

--- a/apis/builder/builder_bid.yaml
+++ b/apis/builder/builder_bid.yaml
@@ -1,0 +1,117 @@
+get:
+  operationId: "getBuilderBid"
+  summary: Get an execution payload bid from an unstaked builder.
+  description: |
+    Requests an unstaked builder node to produce a valid builder bid containing an
+    execution payload header and a `SignedExecutionPayloadBid`. This endpoint is used
+    for unstaked builders who provide full block contents to validators.
+
+    The validator sends a GET request with the following path parameters:
+    - The slot for which the block should be proposed.
+    - The hash of the execution layer block the proposer will build on.
+    - The root of the beacon block the proposer will build on.
+    - The validator's BLS public key.
+
+    The builder responds with a 200 response containing a `SignedBuilderBid` if it can
+    provide one. The bid includes:
+    - An `ExecutionPayloadHeader` for the proposed block
+    - Blob KZG commitments for any associated blobs
+    - Execution requests (deposits, withdrawals, etc.)
+    - A `SignedExecutionPayloadBid` with `builder_index` set to `BUILDER_INDEX_SELF_BUILD`
+
+    If the builder is unable to produce a valid bid, then the builder MUST return a
+    204 response. If the request is invalid, then the builder MUST return an error
+    response (400) with a description of the validation failure.
+
+    This API is applicable from Glamsterdam fork onwards for unstaked builders.
+  tags:
+    - Builder
+  parameters:
+    - name: slot
+      in: path
+      required: true
+      description: The slot for which the block should be proposed.
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Uint64"
+    - name: parent_hash
+      in: path
+      required: true
+      description: Hash of execution layer block the proposer will build on.
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Root"
+    - name: parent_root
+      in: path
+      required: true
+      description: Root of the beacon block the proposer will build on.
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Root"
+    - name: pubkey
+      in: path
+      required: true
+      description: The validator's BLS public key.
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Pubkey"
+    - name: Date-Milliseconds
+      in: header
+      required: false
+      description: |
+        Optional header containing a Unix timestamp in milliseconds representing
+        the point-in-time the request was sent. This header can be used to measure
+        latency.
+      schema:
+        type: integer
+        format: int64
+        example: 1710338135000
+    - name: X-Timeout-Ms
+      in: header
+      required: false
+      description: |
+        Optional header containing the proposer's timeout for the request in milliseconds. 
+        Builders should use this header to adjust the amount of time by which they delay 
+        requests to maximise block rewards. Otherwise, requests will timeout and the proposer 
+        will not receive the bid in time.
+      schema:
+        type: integer
+        format: int64
+        example: 10000
+  responses:
+    "200":
+      description: Success response.
+      headers:
+        Eth-Consensus-Version:
+          $ref: "../../builder-oapi.yaml#/components/headers/Eth-Consensus-Version"
+          required: false
+      content:
+        application/json:
+          schema:
+            title: GetBuilderBidResponse
+            type: object
+            required: [version, data]
+            properties:
+              version:
+                type: string
+                enum: [ gloas ]
+                example: "gloas"
+              data:
+                $ref: "../../types/gloas/builder_bid.yaml#/Gloas/SignedBuilderBid"
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized `SignedBuilderBid` bytes. Use Accept header to choose this response type"
+    "204":
+      description: No bid is available.
+    "400":
+      description: Error response.
+      content:
+        application/json:
+          schema:
+            $ref: "../../builder-oapi.yaml#/components/schemas/ErrorMessage"
+          examples:
+            InvalidRequest:
+              value:
+                code: 400
+                message: "Unknown hash: missing parent hash"
+    "406":
+      $ref: "../../builder-oapi.yaml#/components/responses/NotAcceptable"
+    "500":
+      $ref: "../../builder-oapi.yaml#/components/responses/InternalError"
+

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -29,7 +29,7 @@ get:
     - name: parent_root
       in: path
       required: true
-      description: Root of the execution layer block the proposer will build on.
+      description: Root of the beacon block the proposer will build on.
       schema:
         $ref: "../../builder-oapi.yaml#/components/schemas/Root"
     - name: proposer_index

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -30,7 +30,7 @@ get:
       required: false
       description: |
         Optional header containing the proposer's timeout for the request in milliseconds. 
-        Relays should use this header to adjust the amount of time by which they delay getBid 
+        Builders should use this header to adjust the amount of time by which they delay getBid 
         requests to maximise block rewards. Otherwise, getBid requests will timeout and the proposer 
         will not receive the header in time.
       schema:

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -61,16 +61,6 @@ get:
         type: integer
         format: int64
         example: 10000
-    - name: X-Fee-Recipient
-      in: header
-      required: true
-      description: |
-        Required header containing the fee recipient address to which the proposer wants to receive
-        the payment for the bid.
-      schema: 
-        type: string
-        format: address
-        example: "0x0000000000000000000000000000000000000000"
   responses:
     "200":
       description: Success response.

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -1,14 +1,23 @@
-get:
+post:
   operationId: "getExecutionPayloadBid"
   summary: Get an execution payload bid.
   description: |
     Requests a builder node to produce a valid execution payload bid, which
-    can be integrated into a blinded beacon block and signed.
+    can be integrated into a blinded beacon block and signed. 
+
+    The proposer sends a POST request to the builder with the following information:
+    - The slot for which the block should be proposed.
+    - The hash of the execution layer block the proposer will build on.
+    - The root of the beacon block the proposer will build on.
+    - The index of the proposer.
+    - A signed bid request auth to authenticate the request to a specific builder index.
+
+    The builder responds with a 200 response containing an execution payload bid if it can provide one.
 
     If the builder is unable to produce a valid execution payload bid, then
     the builder MUST return a 204 response. If the request is invalid, then the
     builder MUST return an error response (400) with a description of the
-    validation failure.
+    validation failure. If the SignedBidRequestAuth is invalid, the builder MUST return a 400 response.
 
     This API is applicable from Glamsterdam fork onwards.
   tags:
@@ -55,12 +64,21 @@ get:
       description: |
         Optional header containing the proposer's timeout for the request in milliseconds. 
         Builders should use this header to adjust the amount of time by which they delay getBid 
-        requests to maximise block rewards. Otherwise, getBid requests will timeout and the proposer 
+        requests to maximise block rewards. Otherwise, getExecutionPayloadBid requests will timeout and the proposer 
         will not receive the header in time.
       schema:
         type: integer
         format: int64
         example: 10000
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../../types/gloas/bid_request_auth.yaml#/Gloas/SignedBidRequestAuth"
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized `SignedBidRequestAuth` bytes."
   responses:
     "200":
       description: Success response.
@@ -85,7 +103,7 @@ get:
           schema:
             description: "SSZ serialized `ExecutionPayloadBid` bytes. Use Accept header to choose this response type"
     "204":
-      description: No header is available.
+      description: No bid is available.
     "400":
       description: Error response.
       content:
@@ -93,10 +111,14 @@ get:
           schema:
             $ref: "../../builder-oapi.yaml#/components/schemas/ErrorMessage"
           examples:
-            InvalidRequest:
+            InvalidHash:
               value:
                 code: 400
                 message: "Unknown hash: missing parent hash"
+            InvalidAuth:
+              value:
+                code: 400
+                message: "Invalid SignedBidRequestAuth: signature verification failed"
     "406":
       $ref: "../../builder-oapi.yaml#/components/responses/NotAcceptable"
     "500":

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -1,0 +1,89 @@
+get:
+  operationId: "getExecutionPayloadBid"
+  summary: Get an execution payload bid.
+  description: |
+    Requests a builder node to produce a valid execution payload bid, which
+    can be integrated into a blinded beacon block and signed.
+
+    If the builder is unable to produce a valid execution payload bid, then
+    the builder MUST return a 204 response. If the request is invalid, then the
+    builder MUST return an error response (400) with a description of the
+    validation failure.
+
+    This API is applicable from Glamsterdam fork onwards.
+  tags:
+    - Builder
+  parameters:
+    - name: Date-Milliseconds
+      in: header
+      required: false
+      description: |
+        Optional header containing a Unix timestamp in milliseconds representing
+        the point-in-time the request was sent. This header can be used to measure
+        latency.
+      schema:
+        type: integer
+        format: int64
+        example: 1710338135000
+    - name: X-Timeout-Ms
+      in: header
+      required: false
+      description: |
+        Optional header containing the proposer's timeout for the request in milliseconds. 
+        Relays should use this header to adjust the amount of time by which they delay getBid 
+        requests to maximise block rewards. Otherwise, getBid requests will timeout and the proposer 
+        will not receive the header in time.
+      schema:
+        type: integer
+        format: int64
+        example: 10000
+    - name: X-Fee-Recipient
+      in: header
+      required: true
+      description: |
+        Required header containing the fee recipient address to which the proposer wants to receive
+        the payment for the bid.
+      schema: 
+        type: string
+        format: address
+        example: "0x0000000000000000000000000000000000000000"
+  responses:
+    "200":
+      description: Success response.
+      headers:
+        Eth-Consensus-Version:
+          $ref: "../../builder-oapi.yaml#/components/headers/Eth-Consensus-Version"
+          required: false
+      content:
+        application/json:
+          schema:
+            title: GetExecutionPayloadBidResponse
+            type: object
+            required: [version, data]
+            properties:
+              version:
+                type: string
+                enum: [ gloas ]
+                example: "gloas"
+              data:
+                $ref: "../../beacon-apis/types/gloas/execution_payload_bid.yaml#/Gloas/ExecutionPayloadBid"
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized `ExecutionPayloadBid` bytes. Use Accept header to choose this response type"
+    "204":
+      description: No header is available.
+    "400":
+      description: Error response.
+      content:
+        application/json:
+          schema:
+            $ref: "../../builder-oapi.yaml#/components/schemas/ErrorMessage"
+          examples:
+            InvalidRequest:
+              value:
+                code: 400
+                message: "Unknown hash: missing parent hash"
+    "406":
+      $ref: "../../builder-oapi.yaml#/components/responses/NotAcceptable"
+    "500":
+      $ref: "../../builder-oapi.yaml#/components/responses/InternalError"

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -14,6 +14,30 @@ get:
   tags:
     - Builder
   parameters:
+    - name: slot
+      in: path
+      required: true
+      description: The slot for which the block should be proposed.
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Uint64"
+    - name: parent_hash
+      in: path
+      required: true
+      description: Hash of execution layer block the proposer will build on.
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Root"
+    - name: parent_root
+      in: path
+      required: true
+      description: Root of the execution layer block the proposer will build on.
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Root"
+    - name: proposer_index
+      in: path
+      required: true
+      description: Index of the proposer.
+      schema:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Uint64"
     - name: Date-Milliseconds
       in: header
       required: false

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -10,7 +10,8 @@ post:
     - The hash of the execution layer block the proposer will build on.
     - The root of the beacon block the proposer will build on.
     - The index of the proposer.
-    - A signed bid request auth to authenticate the request to a specific builder index.
+    - A signed bid request auth using a builder-specific salt to authenticate the request. Proposers are required
+    to set the salt to the URL provided by the whitelisted builder.
 
     The builder responds with a 200 response containing an execution payload bid if it can provide one.
 

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -98,10 +98,10 @@ post:
                 enum: [ gloas ]
                 example: "gloas"
               data:
-                $ref: "../../beacon-apis/types/gloas/execution_payload_bid.yaml#/Gloas/ExecutionPayloadBid"
+                $ref: "../../beacon-apis/types/gloas/execution_payload_bid.yaml#/Gloas/SignedExecutionPayloadBid"
         application/octet-stream:
           schema:
-            description: "SSZ serialized `ExecutionPayloadBid` bytes. Use Accept header to choose this response type"
+            description: "SSZ serialized `SignedExecutionPayloadBid` bytes. Use Accept header to choose this response type"
     "204":
       description: No bid is available.
     "400":

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -63,8 +63,8 @@ post:
       required: false
       description: |
         Optional header containing the proposer's timeout for the request in milliseconds. 
-        Builders should use this header to adjust the amount of time by which they delay getBid 
-        requests to maximise block rewards. Otherwise, getExecutionPayloadBid requests will timeout and the proposer 
+        Builders should use this header to adjust the amount of time by which they delay the 
+        requests to maximise block rewards. Otherwise, requests will timeout and the proposer 
         will not receive the header in time.
       schema:
         type: integer

--- a/apis/builder/validators_v2.yaml
+++ b/apis/builder/validators_v2.yaml
@@ -1,0 +1,45 @@
+post:
+  operationId: "registerValidatorV2"
+  summary: Register or update a validator's block building preferences for Gloas.
+  description: |
+    Registers a validator's preferred fee recipient, gas limit and preferences.
+
+    A success response (200) indicates that the registration was valid. If the
+    registration passes validation, then the builder MUST integrate the
+    registration into its state, such that future blocks built for the
+    validator conform to the preferences expressed in the registration. If the
+    registration is invalid, then the builder MUST return an error response
+    (400) with a description of the validation failure.
+  tags:
+    - Builder
+  requestBody:
+    description: |
+      A signed declaration of a validator's block building preferences.
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: "../../builder-oapi.yaml#/components/schemas/SignedValidatorRegistrationV2"
+        example:
+          $ref: "../../builder-oapi.yaml#/components/examples/SignedValidatorRegistrations/value"
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized `List[SignedValidatorRegistrationV2, VALIDATOR_REGISTRY_LIMIT]` bytes. Use content type header to indicate that SSZ data is contained in the request body."
+  responses:
+    "200":
+      description: Success response.
+    "400":
+      description: Error response.
+      content:
+        application/json:
+          schema:
+            $ref: "../../builder-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "unknown validator"
+    "415":
+      $ref: "../../builder-oapi.yaml#/components/responses/UnsupportedMediaType"
+    "500":
+      $ref: "../../builder-oapi.yaml#/components/responses/InternalError"

--- a/apis/builder/validators_v2.yaml
+++ b/apis/builder/validators_v2.yaml
@@ -21,7 +21,7 @@ post:
         schema:
           type: array
           items:
-            $ref: "../../builder-oapi.yaml#/components/schemas/SignedValidatorRegistrationV2"
+            $ref: "../../builder-oapi.yaml#/components/schemas/Gloas.SignedValidatorRegistrationV2"
         example:
           $ref: "../../builder-oapi.yaml#/components/examples/SignedValidatorRegistrations/value"
       application/octet-stream:

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -53,6 +53,10 @@ paths:
     $ref: "./apis/builder/validators.yaml"
   /eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}:
     $ref: "./apis/builder/header.yaml"
+  /eth/v1/builder/execution_payload_bid:
+    $ref: "./apis/builder/execution_payload_bid.yaml"
+  /eth/v1/builder/beacon_block:
+    $ref: "./apis/builder/beacon_block.yaml"
   /eth/v1/builder/blinded_blocks:
     $ref: "./apis/builder/blinded_blocks.yaml"
   /eth/v2/builder/blinded_blocks:
@@ -72,7 +76,7 @@ components:
       $ref: "./beacon-apis/types/http.yaml#/ErrorMessage"
     ConsensusVersion:
       $ref: "./beacon-apis/beacon-node-oapi.yaml#/components/schemas/ConsensusVersion"
-      enum: [bellatrix, capella, deneb, electra, fulu]
+      enum: [bellatrix, capella, deneb, electra, fulu, gloas]
       example: "bellatrix"
     Bellatrix.ExecutionPayload:
       $ref: "./beacon-apis/types/bellatrix/execution_payload.yaml#/Bellatrix/ExecutionPayload"

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -51,6 +51,8 @@ tags:
 paths:
   /eth/v1/builder/validators:
     $ref: "./apis/builder/validators.yaml"
+  /eth/v2/builder/validators:
+    $ref: "./apis/builder/validators_2.yaml"
   /eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}:
     $ref: "./apis/builder/header.yaml"
   /eth/v1/builder/execution_payload_bid/{slot}/{parent_hash}/{parent_root}/{proposer_index}:

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -98,6 +98,8 @@ components:
       $ref: "./types/deneb/execution_payload_and_blobs_bundle.yaml#/Deneb/ExecutionPayloadAndBlobsBundle"
     SignedValidatorRegistration:
       $ref: "./beacon-apis/types/registration.yaml#/SignedValidatorRegistration"
+    SignedValidatorRegistrationV2:
+      $ref: "./beacon-apis/types/registration.yaml#/SignedValidatorRegistrationV2"
     Electra.SignedBlindedBeaconBlock:
       $ref: "./beacon-apis/types/electra/block.yaml#/Electra/SignedBlindedBeaconBlock"
     Electra.SignedBuilderBid:

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -52,7 +52,7 @@ paths:
   /eth/v1/builder/validators:
     $ref: "./apis/builder/validators.yaml"
   /eth/v2/builder/validators:
-    $ref: "./apis/builder/validators_2.yaml"
+    $ref: "./apis/builder/validators_v2.yaml"
   /eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}:
     $ref: "./apis/builder/header.yaml"
   /eth/v1/builder/execution_payload_bid/{slot}/{parent_hash}/{parent_root}/{proposer_index}:

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -110,6 +110,11 @@ components:
       $ref: "./types/fulu/blobs_bundle.yaml#/Fulu/BlobsBundle"
     Fulu.ExecutionPayloadAndBlobsBundle:
       $ref: "./types/fulu/execution_payload_and_blobs_bundle.yaml#/Fulu/ExecutionPayloadAndBlobsBundle"
+    Gloas.BidRequestAuth:
+      $ref: "./types/gloas/bid_request_auth.yaml#/Gloas/BidRequestAuth"
+    Gloas.SignedBidRequestAuth:
+      $ref: "./types/gloas/bid_request_auth.yaml#/Gloas/SignedBidRequestAuth"
+
 
   responses:
     InternalError:

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -53,7 +53,7 @@ paths:
     $ref: "./apis/builder/validators.yaml"
   /eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}:
     $ref: "./apis/builder/header.yaml"
-  /eth/v1/builder/execution_payload_bid:
+  /eth/v1/builder/execution_payload_bid/{slot}/{parent_hash}/{parent_root}/{proposer_index}:
     $ref: "./apis/builder/execution_payload_bid.yaml"
   /eth/v1/builder/beacon_block:
     $ref: "./apis/builder/beacon_block.yaml"

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -100,8 +100,6 @@ components:
       $ref: "./types/deneb/execution_payload_and_blobs_bundle.yaml#/Deneb/ExecutionPayloadAndBlobsBundle"
     SignedValidatorRegistration:
       $ref: "./beacon-apis/types/registration.yaml#/SignedValidatorRegistration"
-    SignedValidatorRegistrationV2:
-      $ref: "./beacon-apis/types/registration.yaml#/SignedValidatorRegistrationV2"
     Electra.SignedBlindedBeaconBlock:
       $ref: "./beacon-apis/types/electra/block.yaml#/Electra/SignedBlindedBeaconBlock"
     Electra.SignedBuilderBid:
@@ -114,8 +112,13 @@ components:
       $ref: "./types/gloas/bid_request_auth.yaml#/Gloas/BidRequestAuth"
     Gloas.SignedBidRequestAuth:
       $ref: "./types/gloas/bid_request_auth.yaml#/Gloas/SignedBidRequestAuth"
-
-
+    Gloas.BuilderPreferences:
+      $ref: "./types/gloas/registration.yaml#/Gloas/BuilderPreferences"
+    Gloas.ValidatorRegistrationV2:
+      $ref: "./types/gloas/registration.yaml#/Gloas/ValidatorRegistrationV2"
+    Gloas.SignedValidatorRegistrationV2:
+      $ref: "./types/gloas/registration.yaml#/Gloas/SignedValidatorRegistrationV2"
+  
   responses:
     InternalError:
       $ref: "./types/http.yaml#/InternalError"

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -108,6 +108,48 @@ def verify_registration_signature(state: BeaconState, signed_registration: Signe
     return bls.Verify(pubkey, signing_root, signed_registration.signature)
 ```
 
+## Bidding
+
+In Gloas, Execution payloads are built for a specific `slot`, `parent_hash`,
+`pubkey` along with the `parent_root` tuple corresponding to a unique beacon
+block serving as the parent.
+
+This is because in Gloas with EIP-7732, the execution payload and beacon blocks
+are decoupled. The `parent_hash` could refer to a beacon block which is an
+ancestor of the parent beacon block corresponding to the current beacon block
+for which we are building the execution payload.
+
+We update `is_eligible_for_bid` below:
+
+```python
+def is_eligible_for_bid(state: BeaconState,
+                        registrations: Dict[BLSPubkey, ValidatorRegistrationV2],
+                        slot: Slot,
+                        parent_hash: Hash32,
+                        # [New in Gloas]
+                        parent_root: Root,
+                        pubkey: BLSPubkey):
+    # Verify slot
+    if slot != state.slot:
+        return False
+
+    # Verify BLS public key corresponds to a registered validator
+    if pubkey not in registrations:
+        return False
+
+    # Verify BLS public key corresponds to the proposer for the slot
+    proposer_index = get_beacon_proposer_index(state)
+    if pubkey != state.validators[proposer_index].pubkey:
+        return False
+
+    # Verify parent hash
+    # [Modified in Gloas:EIP7732]
+    assert parent_hash == state.latest_block_hash
+
+    # Verify parent root
+    assert parent_root == hash_tree_root(state.latest_block_header)
+```
+
 ## Builder Preferences
 
 Using validator registrations, a proposer can express the preferences it has for

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -161,7 +161,7 @@ def process_registration_v2(state: BeaconState,
     assert is_eligible_for_registration(state, validator)
 
     # Verify that the old registration's proposal slot is earlier than the new registration's proposal slot
-    if validator_index in registrations:
+    if validator_index in registrations.keys():
         prev_registration = registrations[validator_index]
         assert registration.proposal_slot >= prev_registration.proposal_slot
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -1,0 +1,34 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Gloas - Builder Specification](#gloas---builder-specification)
+  - [Introduction](#introduction)
+    - [Constructing a `SignedExecutionPayloadBid`](#constructing-a-signedexecutionpayloadbid)
+    - [Constructing a `SignedExecutionPayloadEnvelope`](#constructing-a-signedexecutionpayloadenvelope)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Gloas - Builder Specification
+
+## Introduction
+
+This document documents the builder behaviour with the Builder-API.
+
+### `ValidatorRegistrationV1` are deprecated
+
+With Gloas, `ValidatorRegistrations` are deprecated. Pre-Gloas, Validators used `ValidatorRegistrationV1` to signal their 
+preferred `fee_receipient` and `gas_limit` to the builder. 
+
+Now, A proposer can indicate the `fee_receipient` to which they want the builder to pay as a header while requesting the 
+`SignedExecutionPayloadBid`.
+
+### Constructing a `SignedExecutionPayloadBid`
+
+The specification for a block builder to construct a `SignedExecutionPayloadBid` is documented in the 
+gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].
+
+### Constructing a `SignedExecutionPayloadEnvelope`
+
+The specification for a block builder to construct a `SignedExecutionPayloadEnvelope` is documented in the 
+gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -33,7 +33,7 @@ describes how builders interact with validators through
 ## Constants
 
 | Name | Value | | ---------------------------- | -------------------| |
-`MAX_TRUSTED_BID` | `2**64 - 1`|
+`MAX_TRUSTED_BID` | `2**64 - 1` |
 
 ## Containers
 
@@ -163,7 +163,6 @@ def process_registration_v2(
     state: BeaconState,
     signed_registration: SignedValidatorRegistrationV2,
     registrations: Dict[ValidatorIndex, ValidatorRegistrationV2],
-    current_timestamp: uint64,
 ):
     signature = signed_registration.signature
     registration = signed_registration.message

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -52,7 +52,6 @@ class BuilderPreferences(Container):
 ```python
 class ValidatorRegistrationV2(Container):
     validator_index: ValidatorIndex
-    builder_index: BuilderIndex
     fee_recipient: ExecutionAddress
     proposal_slot: Slot
     gas_limit: uint64
@@ -134,8 +133,6 @@ a builder. Currently, the only preference that is supported is:
 
 The second version of ValidatorRegistrations adds the following new fields:
 
-- `builder_index`: The index of the builder to which the validator is sending
-  the registration.
 - `validator_index`: The index of the validator selected to propose a block at
   slot `proposal_slot`
 - `builder_preferences`: This is a struct which contains the per builder
@@ -162,13 +159,9 @@ def process_registration_v2(state: BeaconState,
     signature = registration.signature
     registration = registration.message
     validator_index = registration.validator_index
-    builder_index = registration.builder_index
     proposal_slot = registration.proposal_slot
 
     validator = state.validators[validator_index]
-    builder = state.builders[builder_index]
-
-    assert is_active_builder(state, builder)
 
     # Verify validator registration elibility
     assert is_eligible_for_registration(state, validator)

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -1,5 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
@@ -8,7 +10,7 @@
   - [Predicates](#predicates)
     - [`is_active_builder`](#is_active_builder)
   - [Helper Functions](#helper-functions)
-      - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
+    - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
   - [Containers](#containers)
     - [New Containers](#new-containers)
       - [`ValidatorRegistrationV2`](#validatorregistrationv2)
@@ -60,6 +62,13 @@ def compute_epoch_at_slot(slot: Slot) -> Epoch:
 
 ### New Containers
 
+#### `BuilderPreferences`
+
+```python
+class BuilderPreferences(Container):
+    execution_payment_accepted: boolean
+```
+
 #### `ValidatorRegistrationV2`
 
 ```python
@@ -69,7 +78,7 @@ class ValidatorRegistrationV2(Container):
     fee_recipient: ExecutionAddress
     proposal_slot: Slot
     gas_limit: uint64
-    execution_payment_accepted: boolean
+    builder_preferences: BuilderPreferences
 ```
 
 #### `SignedValidatorRegistrationV2`
@@ -91,6 +100,15 @@ def verify_registration_signature(state: BeaconState, signed_registration: Signe
     return bls.Verify(pubkey, signing_root, signed_registration.signature)
 ```
 
+## Builder Preferences
+
+Using validator registrations, a proposer can express the preferences it has for
+a builder. Currently, the only preference that is supported is:
+
+- `execution_payment_accepted`: This is a boolean which indicates that the
+  proposer is willing to accept a trusted execution layer payment from the
+  builder.
+
 ## Validator Registration V2
 
 The second version of ValidatorRegistrations adds the following new fields:
@@ -99,9 +117,8 @@ The second version of ValidatorRegistrations adds the following new fields:
   sent.
 - `validator_index`: The index of the validator selected to propose a block at
   slot `proposal_slot`
-- `execution_payment_accepted`: This is a boolean which indicates that the
-  validator is willing accept a trusted execution layer payment from the builder
-  to which it is sending the registrations.
+- `builder_preferences`: This is a struct which contains the per builder
+  preferences the proposer has.
 - `proposal_slot`: The slot at which this validator is proposing.
 
 The following fields are removed:

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -4,6 +4,7 @@
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
   - [Introduction](#introduction)
+  - [Constants](#constants)
   - [Containers](#containers)
     - [New Containers](#new-containers)
       - [`BuilderPreferences`](#builderpreferences)
@@ -28,6 +29,11 @@ describes how builders interact with validators through
 \[`ValidatorRegistrationV2`\][validator-registration-v2] and construct
 [`SignedExecutionPayloadBid`][signed-execution-payload-bid] and
 [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope] objects.
+
+## Constants
+
+| Name | Value | | ---------------------------- | -------------------| |
+`MAX_TRUSTED_BID` | `uint64('2**64-1')`|
 
 ## Containers
 
@@ -125,9 +131,10 @@ a builder. Currently, the only preference that is supported is:
   willing to accept as a trusted execution layer payment from the builder. A
   value of `0` indicates that the proposer does not accept any trusted payments
   from the builder, requiring all payments to be cryptographically verifiable
-  on-chain. A value of `UINT64_MAX` indicates that the proposer will accept any
-  trusted payment amount from the builder. Proposers may adjust this parameter
-  based on their level of trust in the builder's reliability and reputation.
+  on-chain. A value of `MAX_TRUSTED_BID` indicates that the proposer will accept
+  any trusted payment amount from the builder. Proposers may adjust this
+  parameter based on their level of trust in the builder's reliability and
+  reputation.
 
 ## Validator Registration V2
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -6,17 +6,13 @@
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
   - [Introduction](#introduction)
-  - [Custom types](#custom-types)
-  - [Predicates](#predicates)
-    - [`is_active_builder`](#is_active_builder)
-  - [Helper Functions](#helper-functions)
-    - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
   - [Containers](#containers)
     - [New Containers](#new-containers)
       - [`BuilderPreferences`](#builderpreferences)
       - [`ValidatorRegistrationV2`](#validatorregistrationv2)
       - [`SignedValidatorRegistrationV2`](#signedvalidatorregistrationv2)
-    - [`verify_registration_signature`](#verify_registration_signature)
+    - [`verify_registration_v2_signature`](#verify_registration_v2_signature)
+  - [Bidding](#bidding)
   - [Builder Preferences](#builder-preferences)
   - [Validator Registration V2](#validator-registration-v2)
     - [`process_registration_v2`](#process_registration_v2)
@@ -29,12 +25,11 @@
 
 ## Introduction
 
-This document documents the builder behaviour with the Builder-API post ePBS.
-
-## Custom types
-
-| Name | SSZ equivalent | Description | | -------------- | -------------- |
----------------------- | | `BuilderIndex` | `uint64` | Builder registry index |
+This document documents the builder behaviour with the Builder-API post ePBS. It
+describes how builders interact with validators through
+[`ValidatorRegistrationV2`][validator-registration-v2] and construct
+[`SignedExecutionPayloadBid`][signed-execution-payload-bid] and
+[`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope] objects.
 
 ## Containers
 
@@ -66,10 +61,13 @@ class SignedValidatorRegistrationV2(Container):
     signature: BLSSignature
 ```
 
-### `verify_registration_signature`
+### `verify_registration_v2_signature`
+
+*Note*: `compute_domain` and `compute_signing_root` are defined in the
+[Gloas consensus specs][gloas-consensus-specs].
 
 ```python
-def verify_registration_signature(state: BeaconState, signed_registration: SignedValidatorRegistrationV2) -> bool:
+def verify_registration_v2_signature(state: BeaconState, signed_registration: SignedValidatorRegistrationV2) -> bool:
     validator = state.validators[signed_registration.message.validator_index]
     pubkey = validator.pubkey
     domain = compute_domain(DOMAIN_APPLICATION_BUILDER)
@@ -80,35 +78,34 @@ def verify_registration_signature(state: BeaconState, signed_registration: Signe
 ## Bidding
 
 In Gloas, Execution payloads are built for a specific `slot`, `parent_hash`,
-`pubkey` along with the `parent_root` tuple corresponding to a unique beacon
-block serving as the parent.
+`validator_index` along with the `parent_root` tuple corresponding to a unique
+beacon block serving as the parent.
 
-This is because in Gloas with EIP-7732, the execution payload and beacon blocks
-are decoupled. The `parent_hash` could refer to a beacon block which is an
-ancestor of the parent beacon block corresponding to the current beacon block
-for which we are building the execution payload.
+This is because in Gloas with [EIP-7732][eip-7732], the execution payload and
+beacon blocks are decoupled. The `parent_hash` could refer to a beacon block
+which is an ancestor of the parent beacon block corresponding to the current
+beacon block for which we are building the execution payload.
 
-We update `is_eligible_for_bid` below:
+We update `is_eligible_for_bid` below. *Note*: `hash_tree_root` is defined in
+the [Gloas consensus specs][gloas-consensus-specs].
 
 ```python
 def is_eligible_for_bid(state: BeaconState,
-                        registrations: Dict[BLSPubkey, ValidatorRegistrationV2],
+                        registrations: Dict[ValidatorIndex, ValidatorRegistrationV2],
                         slot: Slot,
                         parent_hash: Hash32,
                         # [New in Gloas]
                         parent_root: Root,
-                        pubkey: BLSPubkey):
+                        # [New in Gloas]
+                        validator_index: ValidatorIndex):
     # Verify slot
     if slot != state.slot:
         return False
 
-    # Verify BLS public key corresponds to a registered validator
-    if pubkey not in registrations:
+    if validator_index not in state.validators.keys():
         return False
 
-    # Verify BLS public key corresponds to the proposer for the slot
-    proposer_index = get_beacon_proposer_index(state)
-    if pubkey != state.validators[proposer_index].pubkey:
+    if validator_index not in registrations:
         return False
 
     # Verify parent hash
@@ -149,12 +146,16 @@ The following fields are removed:
 ### `process_registration_v2`
 
 A `validator_registration_v2` is considered valid if the following function
-completes without raising any assertions:
+completes without raising any assertions.
+
+*Note*: [`is_eligible_for_registration`][is-eligible-for-registration] and
+[`verify_registration_signature`][verify-registration-signature] are defined in
+the [Gloas consensus specs][gloas-consensus-specs].
 
 ```python
 def process_registration_v2(state: BeaconState,
                          registration: SignedValidatorRegistrationV2,
-                         registrations: Dict[BLSPubkey, ValidatorRegistrationV2],
+                         registrations: Dict[ValidatorIndex, ValidatorRegistrationV2],
                          current_timestamp: uint64):
     signature = registration.signature
     registration = registration.message
@@ -163,11 +164,11 @@ def process_registration_v2(state: BeaconState,
 
     validator = state.validators[validator_index]
 
-    # Verify validator registration elibility
+    # Verify validator registration eligibility
     assert is_eligible_for_registration(state, validator)
 
     # Verify that the old registration's proposal slot is earlier than the new registration's proposal slot
-    if registration.pubkey in registrations:
+    if validator_index in registrations:
         prev_registration = registrations[validator_index]
         assert registration.proposal_slot >= prev_registration.proposal_slot
 
@@ -177,18 +178,29 @@ def process_registration_v2(state: BeaconState,
 
 ## Constructing a `SignedExecutionPayloadBid`
 
-The specification for a block builder to construct a `SignedExecutionPayloadBid`
-is documented in the
-gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].
+The specification for a block builder to construct a
+[`SignedExecutionPayloadBid`][signed-execution-payload-bid] is documented in the
+[Gloas consensus specs][gloas-builder-specs].
 
 ## Constructing a `SignedExecutionPayloadEnvelope`
 
-If the builder's `SignedExecutionPayloadBid` has been accepted by the proposer
-and it has been included in it's `SignedBeaconBlock`, then the builder has to
-construct a `SignedExecutionPayloadEnvelope` corresponding to the
-`SignedExecutionPayloadBid` and it has to broadcast it to the PTC committee via
-the `execution_payload_envelope` gossip topic.
+If the builder's [`SignedExecutionPayloadBid`][signed-execution-payload-bid] has
+been accepted by the proposer and it has been included in it's
+`SignedBeaconBlock`, then the builder has to construct a
+[`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope]
+corresponding to the [`SignedExecutionPayloadBid`][signed-execution-payload-bid]
+and it has to broadcast it to the PTC committee via the
+`execution_payload_envelope` gossip topic.
 
 The specification for a block builder to construct a
-`SignedExecutionPayloadEnvelope` is documented in the
-gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].
+[`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope] is
+documented in the [Gloas consensus specs][gloas-builder-specs].
+
+[eip-7732]: https://eips.ethereum.org/EIPS/eip-7732
+[gloas-builder-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md
+[gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
+[is-eligible-for-registration]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#is_eligible_for_registration
+[signed-execution-payload-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadbid
+[signed-execution-payload-envelope]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadenvelope
+[validator-registration-v2]: #validatorregistrationv2
+[verify-registration-signature]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#verify_registration_signature

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -29,42 +29,12 @@
 
 ## Introduction
 
-This document documents the builder behaviour with the Builder-API.
+This document documents the builder behaviour with the Builder-API post ePBS.
 
 ## Custom types
 
 | Name | SSZ equivalent | Description | | -------------- | -------------- |
 ---------------------- | | `BuilderIndex` | `uint64` | Builder registry index |
-
-## Predicates
-
-### `is_active_builder`
-
-```python
-def is_active_builder(state: BeaconState, builder_index: BuilderIndex) -> bool:
-    """
-    Check if the builder at ``builder_index`` is active for the given ``state``.
-    """
-    builder = state.builders[builder_index]
-    return (
-        # Placement in builder list is finalized
-        builder.deposit_epoch < state.finalized_checkpoint.epoch
-        # Has not initiated exit
-        and builder.withdrawable_epoch == FAR_FUTURE_EPOCH
-    )
-```
-
-## Helper Functions
-
-#### `compute_epoch_at_slot`
-
-```python
-def compute_epoch_at_slot(slot: Slot) -> Epoch:
-    """
-    Return the epoch number at ``slot``.
-    """
-    return Epoch(slot // SLOTS_PER_EPOCH)
-```
 
 ## Containers
 
@@ -81,8 +51,8 @@ class BuilderPreferences(Container):
 
 ```python
 class ValidatorRegistrationV2(Container):
-    builder_index: BuilderIndex 
     validator_index: ValidatorIndex
+    builder_index: BuilderIndex
     fee_recipient: ExecutionAddress
     proposal_slot: Slot
     gas_limit: uint64
@@ -147,6 +117,7 @@ def is_eligible_for_bid(state: BeaconState,
     assert parent_hash == state.latest_block_hash
 
     # Verify parent root
+    # [Modified in Gloas:EIP7732]
     assert parent_root == hash_tree_root(state.latest_block_header)
 ```
 
@@ -163,8 +134,8 @@ a builder. Currently, the only preference that is supported is:
 
 The second version of ValidatorRegistrations adds the following new fields:
 
-- `builder_index`: The index of the builder to which this registration is being
-  sent.
+- `builder_index`: The index of the builder to which the validator is sending
+  the registration.
 - `validator_index`: The index of the validator selected to propose a block at
   slot `proposal_slot`
 - `builder_preferences`: This is a struct which contains the per builder

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -17,26 +17,100 @@
 
 This document documents the builder behaviour with the Builder-API.
 
-### `ValidatorRegistrationV1` are deprecated
+## Custom types
 
-With Gloas, `ValidatorRegistrations` are deprecated. Pre-Gloas, Validators used `ValidatorRegistrationV1` to signal their 
-preferred `fee_recipient` and `gas_limit` to the builder. 
+| Name           | SSZ equivalent | Description            |
+| -------------- | -------------- | ---------------------- |
+| `BuilderIndex` | `uint64`       | Builder registry index |
 
-Now, A proposer can indicate the `fee_recipient` to which they want the builder to pay as a header while requesting the 
-`SignedExecutionPayloadBid`.
+## Containers
 
-### Constructing a `SignedExecutionPayloadBid`
+### New Containers
+
+#### `ValidatorRegistrationV2`
+
+```python
+class ValidatorRegistrationV2(Container):
+    builder_pubkey: BLSPubkey ## is this needed? 
+    fee_recipient: ExecutionAddress
+    gas_limit: uint64
+    timestamp: uint64
+    pubkey: BLSPubkey
+    can_accept_trusted_payment: bool
+    proposal_epoch: Epoch
+```
+
+#### `SignedValidatorRegistrationV2`
+
+```python
+class SignedValidatorRegistrationV2(Container):
+    message: ValidatorRegistrationV2
+    signature: BLSSignature
+```
+
+### `verify_registration_signature`
+
+```python
+def verify_registration_signature(state: BeaconState, signed_registration: SignedValidatorRegistrationV2) -> bool:
+    pubkey = signed_registration.message.pubkey
+    domain = compute_domain(DOMAIN_APPLICATION_BUILDER)
+    signing_root = compute_signing_root(signed_registration.message, domain)
+    return bls.Verify(pubkey, signing_root, signed_registration.signature)
+```
+
+## Validator Registration V2
+
+The second version of ValidatorRegistrations adds the following new fields:
+* `builder_pubkey`: The pubkey of the builder to which this registration is being sent.
+* `can_accept_trusted_payment`: This is a boolean which indicates that the validator is willing accept a trusted
+  execution layer payment from the builder to which it is sending the registrations.
+* `proposal_epoch`: The epoch at which this validator is proposing.
+
+### `process_registration`
+
+```python
+def process_registration(state: BeaconState,
+                         registration: SignedValidatorRegistrationV2,
+                         registrations: Dict[BLSPubkey, ValidatorRegistrationV2],
+                         current_timestamp: uint64):
+    signature = registration.signature
+    registration = registration.message
+    pubkey = registration.pubkey
+    builder_pubkey = registration.builder_pubkey
+
+    # Verify BLS public key corresponds to a registered validator
+    validator_pubkeys = [v.pubkey for v in state.validators]
+    assert pubkey in validator_pubkeys
+
+    index = ValidatorIndex(validator_pubkeys.index(pubkey))
+    validator = state.validators[index]
+
+    # [New in Gloas]
+    builder_pubkeys = [b.pubkey for v in state.builders]
+    assert builder_pubkey in builder_pubkeys 
+
+    # Verify validator registration elibility
+    assert is_eligible_for_registration(state, validator)
+
+    # Verify timestamp is not too far in the future
+    assert registration.timestamp <= current_timestamp + MAX_REGISTRATION_LOOKAHEAD
+
+    # Verify timestamp is not less than the timestamp of the previous registration (if it exists)
+    if registration.pubkey in registrations:
+        prev_registration = registrations[registration.pubkey]
+        assert registration.timestamp >= prev_registration.timestamp
+
+    # Verify registration signature
+    assert verify_registration_signature(state, registration)
+```
+
+
+## Constructing a `SignedExecutionPayloadBid`
 
 The specification for a block builder to construct a `SignedExecutionPayloadBid` is documented in the 
 gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].
 
-### Constructing a `SignedExecutionPayloadEnvelope`
+## Constructing a `SignedExecutionPayloadEnvelope`
 
 The specification for a block builder to construct a `SignedExecutionPayloadEnvelope` is documented in the 
 gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].
-
-### Sealing the Payload with `fee_recipient`
-
-The builder receives the `fee_recipient` as a header to the call to get the `SignedExecutionPayloadBid`. The builder
-is required to seal the block to be sent with the payment transaction to the `fee_recipient` with the amount specified in the
-`execution_payment` field in the `ExecutionPayloadBid`. 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -1,20 +1,21 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-**Table of Contents** *generated with
-[DocToc](https://github.com/thlorenz/doctoc)*
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
   - [Introduction](#introduction)
   - [Custom types](#custom-types)
+  - [Predicates](#predicates)
+    - [`is_active_builder`](#is_active_builder)
+  - [Helper Functions](#helper-functions)
+      - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
   - [Containers](#containers)
     - [New Containers](#new-containers)
       - [`ValidatorRegistrationV2`](#validatorregistrationv2)
       - [`SignedValidatorRegistrationV2`](#signedvalidatorregistrationv2)
     - [`verify_registration_signature`](#verify_registration_signature)
   - [Validator Registration V2](#validator-registration-v2)
-    - [`process_registration`](#process_registration)
+    - [`process_registration_v2`](#process_registration_v2)
   - [Constructing a `SignedExecutionPayloadBid`](#constructing-a-signedexecutionpayloadbid)
   - [Constructing a `SignedExecutionPayloadEnvelope`](#constructing-a-signedexecutionpayloadenvelope)
 
@@ -111,6 +112,9 @@ The following fields are removed:
   builder in the epoch prior to one where
 
 ### `process_registration_v2`
+
+A `validator_registration_v2` is considered valid if the following function
+completes without raising any assertions:
 
 ```python
 def process_registration_v2(state: BeaconState,

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -29,6 +29,30 @@ This document documents the builder behaviour with the Builder-API.
 | -------------- | -------------- | ---------------------- |
 | `BuilderIndex` | `uint64`       | Builder registry index |
 
+## Predicates
+
+### `is_active_builder`
+
+```python
+def is_active_builder(builder: Builder) -> bool:
+    """
+    Check if ``builder`` is active.
+    """
+    return builder.exit_epoch == FAR_FUTURE_EPOCH
+```
+
+## Helper Functions
+
+#### `compute_epoch_at_slot`
+
+```python
+def compute_epoch_at_slot(slot: Slot) -> Epoch:
+    """
+    Return the epoch number at ``slot``.
+    """
+    return Epoch(slot // SLOTS_PER_EPOCH)
+```
+
 ## Containers
 
 ### New Containers
@@ -37,13 +61,12 @@ This document documents the builder behaviour with the Builder-API.
 
 ```python
 class ValidatorRegistrationV2(Container):
-    builder_pubkey: BLSPubkey ## is this needed? 
+    builder_index: BuilderIndex 
+    validator_index: ValidatorIndex
     fee_recipient: ExecutionAddress
+    proposal_slot: Slot
     gas_limit: uint64
-    timestamp: uint64
-    pubkey: BLSPubkey
-    can_accept_trusted_payment: bool
-    proposal_epoch: Epoch
+    execution_payment_accepted: boolean
 ```
 
 #### `SignedValidatorRegistrationV2`
@@ -58,7 +81,8 @@ class SignedValidatorRegistrationV2(Container):
 
 ```python
 def verify_registration_signature(state: BeaconState, signed_registration: SignedValidatorRegistrationV2) -> bool:
-    pubkey = signed_registration.message.pubkey
+    validator = state.validators[signed_registration.message.validator_index]
+    pubkey = validator.pubkey
     domain = compute_domain(DOMAIN_APPLICATION_BUILDER)
     signing_root = compute_signing_root(signed_registration.message, domain)
     return bls.Verify(pubkey, signing_root, signed_registration.signature)
@@ -67,49 +91,50 @@ def verify_registration_signature(state: BeaconState, signed_registration: Signe
 ## Validator Registration V2
 
 The second version of ValidatorRegistrations adds the following new fields:
-* `builder_pubkey`: The pubkey of the builder to which this registration is being sent.
-* `can_accept_trusted_payment`: This is a boolean which indicates that the validator is willing accept a trusted
+* `builder_index`: The index of the builder to which this registration is being sent.
+* `validator_index`: The index of the validator selected to propose a block at slot `proposal_slot`
+* `execution_payment_accepted`: This is a boolean which indicates that the validator is willing accept a trusted
   execution layer payment from the builder to which it is sending the registrations.
-* `proposal_epoch`: The epoch at which this validator is proposing.
+* `proposal_slot`: The slot at which this validator is proposing.
 
-### `process_registration`
+The following fields are removed:
+* `pubkey`: This is the pubkey of the validator which has now been replaced with `validator_index`.
+* `timestamp`: A new validator registration will be sent by the validator to the builder in 
+  the epoch prior to one where 
+
+### `process_registration_v2`
 
 ```python
-def process_registration(state: BeaconState,
+def process_registration_v2(state: BeaconState,
                          registration: SignedValidatorRegistrationV2,
                          registrations: Dict[BLSPubkey, ValidatorRegistrationV2],
                          current_timestamp: uint64):
     signature = registration.signature
     registration = registration.message
-    pubkey = registration.pubkey
-    builder_pubkey = registration.builder_pubkey
+    validator_index = registration.validator_index
+    builder_index = registration.builder_index
+    proposal_slot = registration.proposal_slot
 
-    # Verify BLS public key corresponds to a registered validator
-    validator_pubkeys = [v.pubkey for v in state.validators]
-    assert pubkey in validator_pubkeys
+    assert validator_index < len(state.validators)
+    assert builder_index < len(state.builders)
 
-    index = ValidatorIndex(validator_pubkeys.index(pubkey))
-    validator = state.validators[index]
+    validator = state.validators[validator_index]
+    builder = state.builders[builder_index]
 
-    # [New in Gloas]
-    builder_pubkeys = [b.pubkey for v in state.builders]
-    assert builder_pubkey in builder_pubkeys 
+    assert is_active_validator(validator, compute_epoch_at_slot(proposal_slot))
+    assert is_active_builder(builder)
 
     # Verify validator registration elibility
     assert is_eligible_for_registration(state, validator)
 
-    # Verify timestamp is not too far in the future
-    assert registration.timestamp <= current_timestamp + MAX_REGISTRATION_LOOKAHEAD
-
-    # Verify timestamp is not less than the timestamp of the previous registration (if it exists)
+    # Verify that the old registration's slot is earlier than the new registration's slot
     if registration.pubkey in registrations:
-        prev_registration = registrations[registration.pubkey]
-        assert registration.timestamp >= prev_registration.timestamp
+        prev_registration = registrations[validator_index]
+        assert registration.proposal_slot >= prev_registration.proposal_slot
 
     # Verify registration signature
     assert verify_registration_signature(state, registration)
 ```
-
 
 ## Constructing a `SignedExecutionPayloadBid`
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -1,4 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
@@ -31,9 +32,8 @@ describes how builders interact with validators through
 
 ## Constants
 
-| Name                                      | Value              |
-| ----------------------------------------- | ------------------ |
-| `MAX_TRUSTED_BID`                         | `2**64 - 1`        |
+| Name | Value | | ----------------------------------------- |
+------------------ | | `MAX_TRUSTED_BID` | `2**64 - 1` |
 
 ## Containers
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -27,7 +27,7 @@
 
 This document documents the builder behaviour with the Builder-API post ePBS. It
 describes how builders interact with validators through
-[`ValidatorRegistrationV2`][validator-registration-v2] and construct
+\[`ValidatorRegistrationV2`\][validator-registration-v2] and construct
 [`SignedExecutionPayloadBid`][signed-execution-payload-bid] and
 [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope] objects.
 
@@ -81,10 +81,10 @@ In Gloas, Execution payloads are built for a specific `slot`, `parent_hash`,
 `validator_index` along with the `parent_root` tuple corresponding to a unique
 beacon block serving as the parent.
 
-This is because in Gloas with [EIP-7732][eip-7732], the execution payload and
-beacon blocks are decoupled. The `parent_hash` could refer to a beacon block
-which is an ancestor of the parent beacon block corresponding to the current
-beacon block for which we are building the execution payload.
+This is because in Gloas with [EIP-7732], the execution payload and beacon
+blocks are decoupled. The `parent_hash` could refer to a beacon block which is
+an ancestor of the parent beacon block corresponding to the current beacon block
+for which we are building the execution payload.
 
 We update `is_eligible_for_bid` below. *Note*: `hash_tree_root` is defined in
 the [Gloas consensus specs][gloas-consensus-specs].
@@ -99,14 +99,11 @@ def is_eligible_for_bid(state: BeaconState,
                         # [New in Gloas]
                         validator_index: ValidatorIndex):
     # Verify slot
-    if slot != state.slot:
-        return False
+    assert slot == state.slot
 
-    if validator_index not in state.validators.keys():
-        return False
+    assert validator_index in state.validator.keys()
 
-    if validator_index not in registrations:
-        return False
+    assert validator_index in registrations.keys()
 
     # Verify parent hash
     # [Modified in Gloas:EIP7732]
@@ -148,10 +145,6 @@ The following fields are removed:
 A `validator_registration_v2` is considered valid if the following function
 completes without raising any assertions.
 
-*Note*: [`is_eligible_for_registration`][is-eligible-for-registration] and
-[`verify_registration_signature`][verify-registration-signature] are defined in
-the [Gloas consensus specs][gloas-consensus-specs].
-
 ```python
 def process_registration_v2(state: BeaconState,
                          registration: SignedValidatorRegistrationV2,
@@ -173,7 +166,7 @@ def process_registration_v2(state: BeaconState,
         assert registration.proposal_slot >= prev_registration.proposal_slot
 
     # Verify registration signature
-    assert verify_registration_signature(state, registration)
+    assert verify_registration_v2_signature(state, registration)
 ```
 
 ## Constructing a `SignedExecutionPayloadBid`
@@ -199,8 +192,5 @@ documented in the [Gloas consensus specs][gloas-builder-specs].
 [eip-7732]: https://eips.ethereum.org/EIPS/eip-7732
 [gloas-builder-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md
 [gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
-[is-eligible-for-registration]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#is_eligible_for_registration
 [signed-execution-payload-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadbid
 [signed-execution-payload-envelope]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadenvelope
-[validator-registration-v2]: #validatorregistrationv2
-[verify-registration-signature]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#verify_registration_signature

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -1,6 +1,9 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+**Table of Contents** *generated with
+[DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
   - [Introduction](#introduction)
@@ -25,9 +28,8 @@ This document documents the builder behaviour with the Builder-API.
 
 ## Custom types
 
-| Name           | SSZ equivalent | Description            |
-| -------------- | -------------- | ---------------------- |
-| `BuilderIndex` | `uint64`       | Builder registry index |
+| Name | SSZ equivalent | Description | | -------------- | -------------- |
+---------------------- | | `BuilderIndex` | `uint64` | Builder registry index |
 
 ## Predicates
 
@@ -91,16 +93,22 @@ def verify_registration_signature(state: BeaconState, signed_registration: Signe
 ## Validator Registration V2
 
 The second version of ValidatorRegistrations adds the following new fields:
-* `builder_index`: The index of the builder to which this registration is being sent.
-* `validator_index`: The index of the validator selected to propose a block at slot `proposal_slot`
-* `execution_payment_accepted`: This is a boolean which indicates that the validator is willing accept a trusted
-  execution layer payment from the builder to which it is sending the registrations.
-* `proposal_slot`: The slot at which this validator is proposing.
+
+- `builder_index`: The index of the builder to which this registration is being
+  sent.
+- `validator_index`: The index of the validator selected to propose a block at
+  slot `proposal_slot`
+- `execution_payment_accepted`: This is a boolean which indicates that the
+  validator is willing accept a trusted execution layer payment from the builder
+  to which it is sending the registrations.
+- `proposal_slot`: The slot at which this validator is proposing.
 
 The following fields are removed:
-* `pubkey`: This is the pubkey of the validator which has now been replaced with `validator_index`.
-* `timestamp`: A new validator registration will be sent by the validator to the builder in 
-  the epoch prior to one where 
+
+- `pubkey`: This is the pubkey of the validator which has now been replaced with
+  `validator_index`.
+- `timestamp`: A new validator registration will be sent by the validator to the
+  builder in the epoch prior to one where
 
 ### `process_registration_v2`
 
@@ -138,10 +146,12 @@ def process_registration_v2(state: BeaconState,
 
 ## Constructing a `SignedExecutionPayloadBid`
 
-The specification for a block builder to construct a `SignedExecutionPayloadBid` is documented in the 
+The specification for a block builder to construct a `SignedExecutionPayloadBid`
+is documented in the
 gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].
 
 ## Constructing a `SignedExecutionPayloadEnvelope`
 
-The specification for a block builder to construct a `SignedExecutionPayloadEnvelope` is documented in the 
+The specification for a block builder to construct a
+`SignedExecutionPayloadEnvelope` is documented in the
 gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -4,8 +4,10 @@
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
   - [Introduction](#introduction)
+    - [`ValidatorRegistrationV1` are deprecated](#validatorregistrationv1-are-deprecated)
     - [Constructing a `SignedExecutionPayloadBid`](#constructing-a-signedexecutionpayloadbid)
     - [Constructing a `SignedExecutionPayloadEnvelope`](#constructing-a-signedexecutionpayloadenvelope)
+    - [Sealing the Payload with `fee_recipient`](#sealing-the-payload-with-fee_recipient)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -18,9 +20,9 @@ This document documents the builder behaviour with the Builder-API.
 ### `ValidatorRegistrationV1` are deprecated
 
 With Gloas, `ValidatorRegistrations` are deprecated. Pre-Gloas, Validators used `ValidatorRegistrationV1` to signal their 
-preferred `fee_receipient` and `gas_limit` to the builder. 
+preferred `fee_recipient` and `gas_limit` to the builder. 
 
-Now, A proposer can indicate the `fee_receipient` to which they want the builder to pay as a header while requesting the 
+Now, A proposer can indicate the `fee_recipient` to which they want the builder to pay as a header while requesting the 
 `SignedExecutionPayloadBid`.
 
 ### Constructing a `SignedExecutionPayloadBid`
@@ -32,3 +34,9 @@ gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/
 
 The specification for a block builder to construct a `SignedExecutionPayloadEnvelope` is documented in the 
 gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].
+
+### Sealing the Payload with `fee_recipient`
+
+The builder receives the `fee_recipient` as a header to the call to get the `SignedExecutionPayloadBid`. The builder
+is required to seal the block to be sent with the payment transaction to the `fee_recipient` with the amount specified in the
+`execution_payment` field in the `ExecutionPayloadBid`. 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -1,5 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
@@ -8,7 +10,7 @@
   - [Predicates](#predicates)
     - [`is_active_builder`](#is_active_builder)
   - [Helper Functions](#helper-functions)
-      - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
+    - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
   - [Containers](#containers)
     - [New Containers](#new-containers)
       - [`BuilderPreferences`](#builderpreferences)
@@ -39,11 +41,17 @@ This document documents the builder behaviour with the Builder-API.
 ### `is_active_builder`
 
 ```python
-def is_active_builder(builder: Builder) -> bool:
+def is_active_builder(state: BeaconState, builder_index: BuilderIndex) -> bool:
     """
-    Check if ``builder`` is active.
+    Check if the builder at ``builder_index`` is active for the given ``state``.
     """
-    return builder.exit_epoch == FAR_FUTURE_EPOCH
+    builder = state.builders[builder_index]
+    return (
+        # Placement in builder list is finalized
+        builder.deposit_epoch < state.finalized_checkpoint.epoch
+        # Has not initiated exit
+        and builder.withdrawable_epoch == FAR_FUTURE_EPOCH
+    )
 ```
 
 ## Helper Functions
@@ -144,19 +152,15 @@ def process_registration_v2(state: BeaconState,
     builder_index = registration.builder_index
     proposal_slot = registration.proposal_slot
 
-    assert validator_index < len(state.validators)
-    assert builder_index < len(state.builders)
-
     validator = state.validators[validator_index]
     builder = state.builders[builder_index]
 
-    assert is_active_validator(validator, compute_epoch_at_slot(proposal_slot))
-    assert is_active_builder(builder)
+    assert is_active_builder(state, builder)
 
     # Verify validator registration elibility
     assert is_eligible_for_registration(state, validator)
 
-    # Verify that the old registration's slot is earlier than the new registration's slot
+    # Verify that the old registration's proposal slot is earlier than the new registration's proposal slot
     if registration.pubkey in registrations:
         prev_registration = registrations[validator_index]
         assert registration.proposal_slot >= prev_registration.proposal_slot
@@ -172,6 +176,12 @@ is documented in the
 gloas-specs[https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md].
 
 ## Constructing a `SignedExecutionPayloadEnvelope`
+
+If the builder's `SignedExecutionPayloadBid` has been accepted by the proposer
+and it has been included in it's `SignedBeaconBlock`, then the builder has to
+construct a `SignedExecutionPayloadEnvelope` corresponding to the
+`SignedExecutionPayloadBid` and it has to broadcast it to the PTC committee via
+the `execution_payload_envelope` gossip topic.
 
 The specification for a block builder to construct a
 `SignedExecutionPayloadEnvelope` is documented in the

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -1,5 +1,4 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
@@ -32,8 +31,9 @@ describes how builders interact with validators through
 
 ## Constants
 
-| Name | Value | | ---------------------------- | -------------------| |
-`MAX_TRUSTED_BID` | `2**64 - 1` |
+| Name                                      | Value              |
+| ----------------------------------------- | ------------------ |
+| `MAX_TRUSTED_BID`                         | `2**64 - 1`        |
 
 ## Containers
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -1,7 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
@@ -10,12 +8,14 @@
   - [Predicates](#predicates)
     - [`is_active_builder`](#is_active_builder)
   - [Helper Functions](#helper-functions)
-    - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
+      - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
   - [Containers](#containers)
     - [New Containers](#new-containers)
+      - [`BuilderPreferences`](#builderpreferences)
       - [`ValidatorRegistrationV2`](#validatorregistrationv2)
       - [`SignedValidatorRegistrationV2`](#signedvalidatorregistrationv2)
     - [`verify_registration_signature`](#verify_registration_signature)
+  - [Builder Preferences](#builder-preferences)
   - [Validator Registration V2](#validator-registration-v2)
     - [`process_registration_v2`](#process_registration_v2)
   - [Constructing a `SignedExecutionPayloadBid`](#constructing-a-signedexecutionpayloadbid)

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -4,10 +4,16 @@
 
 - [Gloas - Builder Specification](#gloas---builder-specification)
   - [Introduction](#introduction)
-    - [`ValidatorRegistrationV1` are deprecated](#validatorregistrationv1-are-deprecated)
-    - [Constructing a `SignedExecutionPayloadBid`](#constructing-a-signedexecutionpayloadbid)
-    - [Constructing a `SignedExecutionPayloadEnvelope`](#constructing-a-signedexecutionpayloadenvelope)
-    - [Sealing the Payload with `fee_recipient`](#sealing-the-payload-with-fee_recipient)
+  - [Custom types](#custom-types)
+  - [Containers](#containers)
+    - [New Containers](#new-containers)
+      - [`ValidatorRegistrationV2`](#validatorregistrationv2)
+      - [`SignedValidatorRegistrationV2`](#signedvalidatorregistrationv2)
+    - [`verify_registration_signature`](#verify_registration_signature)
+  - [Validator Registration V2](#validator-registration-v2)
+    - [`process_registration`](#process_registration)
+  - [Constructing a `SignedExecutionPayloadBid`](#constructing-a-signedexecutionpayloadbid)
+  - [Constructing a `SignedExecutionPayloadEnvelope`](#constructing-a-signedexecutionpayloadenvelope)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -126,7 +126,7 @@ The following fields are removed:
 - `pubkey`: This is the pubkey of the validator which has now been replaced with
   `validator_index`.
 - `timestamp`: A new validator registration will be sent by the validator to the
-  builder in the epoch prior to one where
+  builder in the epoch prior to one where they will be proposing.
 
 ### `process_registration_v2`
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -39,7 +39,7 @@ describes how builders interact with validators through
 
 ```python
 class BuilderPreferences(Container):
-    execution_payment_accepted: boolean
+    max_trusted_bid: uint64
 ```
 
 #### `ValidatorRegistrationV2`
@@ -119,9 +119,13 @@ def is_eligible_for_bid(state: BeaconState,
 Using validator registrations, a proposer can express the preferences it has for
 a builder. Currently, the only preference that is supported is:
 
-- `execution_payment_accepted`: This is a boolean which indicates that the
-  proposer is willing to accept a trusted execution layer payment from the
-  builder.
+- `max_trusted_bid`: Specifies the maximum value (in Gwei) that a proposer is
+  willing to accept as a trusted execution layer payment from the builder. A
+  value of `0` indicates that the proposer does not accept any trusted payments
+  from the builder, requiring all payments to be cryptographically verifiable
+  on-chain. A value of `UINT64_MAX` indicates that the proposer will accept any
+  trusted payment amount from the builder. Proposers may adjust this parameter
+  based on their level of trust in the builder's reliability and reputation.
 
 ## Validator Registration V2
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -26,14 +26,14 @@
 
 This document documents the builder behaviour with the Builder-API post ePBS. It
 describes how builders interact with validators through
-\[`ValidatorRegistrationV2`\][validator-registration-v2] and construct
+[`ValidatorRegistrationV2`][validator-registration-v2] and construct
 [`SignedExecutionPayloadBid`][signed-execution-payload-bid] and
 [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope] objects.
 
 ## Constants
 
 | Name | Value | | ---------------------------- | -------------------| |
-`MAX_TRUSTED_BID` | `uint64('2**64-1')`|
+`MAX_TRUSTED_BID` | `2**64 - 1`|
 
 ## Containers
 
@@ -109,7 +109,7 @@ def is_eligible_for_bid(
     # Verify slot
     assert slot == state.slot
 
-    assert validator_index in state.validator.keys()
+    assert validator_index in state.validators.keys()
 
     assert validator_index in registrations.keys()
 
@@ -161,12 +161,12 @@ completes without raising any assertions.
 ```python
 def process_registration_v2(
     state: BeaconState,
-    registration: SignedValidatorRegistrationV2,
+    signed_registration: SignedValidatorRegistrationV2,
     registrations: Dict[ValidatorIndex, ValidatorRegistrationV2],
     current_timestamp: uint64,
 ):
-    signature = registration.signature
-    registration = registration.message
+    signature = signed_registration.signature
+    registration = signed_registration.message
     validator_index = registration.validator_index
     proposal_slot = registration.proposal_slot
 
@@ -181,7 +181,7 @@ def process_registration_v2(
         assert registration.proposal_slot >= prev_registration.proposal_slot
 
     # Verify registration signature
-    assert verify_registration_v2_signature(state, registration)
+    assert verify_registration_v2_signature(state, signed_registration)
 ```
 
 ## Constructing a `SignedExecutionPayloadBid`
@@ -193,7 +193,7 @@ The specification for a block builder to construct a
 ## Constructing a `SignedExecutionPayloadEnvelope`
 
 If the builder's [`SignedExecutionPayloadBid`][signed-execution-payload-bid] has
-been accepted by the proposer and it has been included in the
+been accepted by the proposer and it has been included in its
 `SignedBeaconBlock`, then the builder has to construct a
 [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope]
 corresponding to the [`SignedExecutionPayloadBid`][signed-execution-payload-bid]
@@ -209,3 +209,4 @@ documented in the [Gloas consensus specs][gloas-builder-specs].
 [gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
 [signed-execution-payload-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadbid
 [signed-execution-payload-envelope]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadenvelope
+[validator-registration-v2]: #validatorregistrationv2

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -2,8 +2,6 @@
 
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 - [Gloas - Builder Specification](#gloas---builder-specification)
   - [Introduction](#introduction)
   - [Containers](#containers)
@@ -67,7 +65,9 @@ class SignedValidatorRegistrationV2(Container):
 [Gloas consensus specs][gloas-consensus-specs].
 
 ```python
-def verify_registration_v2_signature(state: BeaconState, signed_registration: SignedValidatorRegistrationV2) -> bool:
+def verify_registration_v2_signature(
+    state: BeaconState, signed_registration: SignedValidatorRegistrationV2
+) -> bool:
     validator = state.validators[signed_registration.message.validator_index]
     pubkey = validator.pubkey
     domain = compute_domain(DOMAIN_APPLICATION_BUILDER)
@@ -90,14 +90,16 @@ We update `is_eligible_for_bid` below. *Note*: `hash_tree_root` is defined in
 the [Gloas consensus specs][gloas-consensus-specs].
 
 ```python
-def is_eligible_for_bid(state: BeaconState,
-                        registrations: Dict[ValidatorIndex, ValidatorRegistrationV2],
-                        slot: Slot,
-                        parent_hash: Hash32,
-                        # [New in Gloas]
-                        parent_root: Root,
-                        # [New in Gloas]
-                        validator_index: ValidatorIndex):
+def is_eligible_for_bid(
+    state: BeaconState,
+    registrations: Dict[ValidatorIndex, ValidatorRegistrationV2],
+    slot: Slot,
+    parent_hash: Hash32,
+    # [New in Gloas]
+    parent_root: Root,
+    # [New in Gloas]
+    validator_index: ValidatorIndex,
+):
     # Verify slot
     assert slot == state.slot
 
@@ -150,10 +152,12 @@ A `validator_registration_v2` is considered valid if the following function
 completes without raising any assertions.
 
 ```python
-def process_registration_v2(state: BeaconState,
-                         registration: SignedValidatorRegistrationV2,
-                         registrations: Dict[ValidatorIndex, ValidatorRegistrationV2],
-                         current_timestamp: uint64):
+def process_registration_v2(
+    state: BeaconState,
+    registration: SignedValidatorRegistrationV2,
+    registrations: Dict[ValidatorIndex, ValidatorRegistrationV2],
+    current_timestamp: uint64,
+):
     signature = registration.signature
     registration = registration.message
     validator_index = registration.validator_index
@@ -182,7 +186,7 @@ The specification for a block builder to construct a
 ## Constructing a `SignedExecutionPayloadEnvelope`
 
 If the builder's [`SignedExecutionPayloadBid`][signed-execution-payload-bid] has
-been accepted by the proposer and it has been included in it's
+been accepted by the proposer and it has been included in the
 `SignedBeaconBlock`, then the builder has to construct a
 [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope]
 corresponding to the [`SignedExecutionPayloadBid`][signed-execution-payload-bid]

--- a/specs/gloas/unstaked_builder.md
+++ b/specs/gloas/unstaked_builder.md
@@ -1,0 +1,282 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Gloas - Unstaked Builder Specification](#gloas---unstaked-builder-specification)
+  - [Introduction](#introduction)
+  - [Flow Overview](#flow-overview)
+  - [Constants](#constants)
+  - [Containers](#containers)
+    - [Modified Containers](#modified-containers)
+      - [`BuilderBid`](#builderbid)
+      - [`SignedBuilderBid`](#signedbuilderbid)
+    - [New Containers](#new-containers)
+      - [`BlindedExecutionPayloadEnvelope`](#blindedexecutionpayloadenvelope)
+      - [`SignedBlindedExecutionPayloadEnvelope`](#signedblindedexecutionpayloadenvelope)
+      - [`BlockAndBlindedEnvelope`](#blockandblindedenvelope)
+  - [Builder Behaviour](#builder-behaviour)
+    - [Constructing a `SignedBuilderBid`](#constructing-a-signedbuilderbid)
+    - [Processing `submitBlockAndEnvelope`](#processing-submitblockandenvelope)
+    - [`verify_blinded_envelope_signature`](#verify_blinded_envelope_signature)
+    - [`process_block_and_envelope`](#process_block_and_envelope)
+  - [Constructing a `SignedExecutionPayloadEnvelope`](#constructing-a-signedexecutionpayloadenvelope)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Gloas - Unstaked Builder Specification
+
+## Introduction
+
+This document specifies the behaviour for unstaked builders interacting with
+validators through the Builder-API in Gloas. Unlike staked builders who have
+collateral on the beacon chain, unstaked builders operate through a relay-like
+mechanism where they provide full block contents to validators.
+
+The key difference from the staked builder flow is that unstaked builders use
+`BUILDER_INDEX_SELF_BUILD` as their builder index in the
+`SignedExecutionPayloadBid`, indicating that the proposer is effectively
+self-building with the unstaked builder's block contents.
+
+## Flow Overview
+
+The unstaked builder interaction follows these steps:
+
+1. **Validator queries bid**: The validator calls the
+   [`getBuilderBid`][get-builder-bid-api] API to get a `SignedBuilderBid`
+   containing the execution payload header, blob KZG commitments, execution
+   requests, and a `SignedExecutionPayloadBid`.
+
+2. **Validator constructs block**: Upon receiving the bid, the validator:
+
+   - Assembles a `SignedBeaconBlock` with the `ExecutionPayloadBid` from the
+     builder
+   - Constructs a `SignedBlindedExecutionPayloadEnvelope` using the
+     `beacon_block_root` of the `SignedBeaconBlock`
+
+3. **Validator submits to builder**: The validator returns both the
+   `SignedBlindedExecutionPayloadEnvelope` and `SignedBeaconBlock` to the
+   builder via the [`submitBlockAndEnvelope`][submit-block-and-envelope-api]
+   API.
+
+4. **Builder broadcasts envelope**: The builder constructs the full
+   `SignedExecutionPayloadEnvelope` (unblinding the blinded version) and
+   broadcasts it to the PTC committee via the `execution_payload_envelope`
+   gossip topic.
+
+## Constants
+
+| Name | Value | | ----------------------------------------- |
+------------------ | | `BUILDER_INDEX_SELF_BUILD` | `2**64 - 1` |
+
+## Containers
+
+### Modified Containers
+
+#### `BuilderBid`
+
+`SignedBuilderBid` is indirectly updated through `BuilderBid`. The `value` and
+`pubkey` fields have been removed since they are absorbed by the
+`SignedExecutionPayloadBid`.
+
+*Note*: The `builder_index` in the `SignedExecutionPayloadBid` MUST be set to
+`BUILDER_INDEX_SELF_BUILD` for unstaked builders.
+
+```python
+class BuilderBid(Container):
+    header: ExecutionPayloadHeader
+    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    execution_requests: ExecutionRequests
+    bid: SignedExecutionPayloadBid  # [New in Gloas]
+```
+
+#### `SignedBuilderBid`
+
+```python
+class SignedBuilderBid(Container):
+    message: BuilderBid
+    signature: BLSSignature
+```
+
+### New Containers
+
+#### `BlindedExecutionPayloadEnvelope`
+
+The `BlindedExecutionPayloadEnvelope` contains the roots of the execution
+payload components rather than the full data. This allows the validator to
+commit to the envelope without having access to the full execution payload.
+
+```python
+class BlindedExecutionPayloadEnvelope(Container):
+    payload_root: Root
+    execution_requests_root: Root
+    builder_index: BuilderIndex
+    beacon_block_root: Root
+    slot: Slot
+    blob_kzg_commitments_root: Root
+    state_root: Root
+```
+
+#### `SignedBlindedExecutionPayloadEnvelope`
+
+```python
+class SignedBlindedExecutionPayloadEnvelope(Container):
+    message: BlindedExecutionPayloadEnvelope
+    signature: BLSSignature
+```
+
+#### `BlockAndBlindedEnvelope`
+
+Container for submitting both the signed beacon block and blinded envelope
+together.
+
+```python
+class BlockAndBlindedEnvelope(Container):
+    signed_beacon_block: SignedBeaconBlock
+    signed_blinded_envelope: SignedBlindedExecutionPayloadEnvelope
+```
+
+## Builder Behaviour
+
+### Constructing a `SignedBuilderBid`
+
+When a builder receives a request for a bid via the
+[`getBuilderBid`][get-builder-bid-api] API, it MUST construct a
+`SignedBuilderBid` with the following:
+
+1. **header**: The `ExecutionPayloadHeader` for the block being built
+2. **blob_kzg_commitments**: The KZG commitments for any blobs attached to the
+   execution payload
+3. **execution_requests**: The execution layer requests (deposits, withdrawals,
+   etc.)
+4. **bid**: A `SignedExecutionPayloadBid` where:
+   - `builder_index` MUST be set to `BUILDER_INDEX_SELF_BUILD`
+   - Other fields follow the [Gloas consensus specs][gloas-builder-specs]
+
+The builder signs the `BuilderBid` message using its BLS private key.
+
+### Processing `submitBlockAndEnvelope`
+
+When a builder receives a `BlockAndBlindedEnvelope` via the
+[`submitBlockAndEnvelope`][submit-block-and-envelope-api] API, it MUST:
+
+1. **Validate the signed beacon block**: Verify the block signature and ensure
+   the `ExecutionPayloadBid` in the block body matches the bid previously
+   provided
+
+2. **Validate the blinded envelope**: Verify that:
+
+   - The `beacon_block_root` matches
+     `hash_tree_root(signed_beacon_block.message)`
+   - The `payload_root` matches the execution payload the builder constructed
+   - The `execution_requests_root` matches the execution requests
+   - The `blob_kzg_commitments_root` matches the commitments
+   - The signature is valid from the proposer
+
+3. **Construct the full envelope**: Create a `SignedExecutionPayloadEnvelope`
+   by:
+
+   - Unblinding the payload root with the actual execution payload
+   - Including the full execution requests and blob commitments
+   - Copying the `beacon_block_root`, `slot`, `builder_index`, and `state_root`
+   - Signing with the builder's key
+
+4. **Broadcast**: Broadcast the `SignedExecutionPayloadEnvelope` to the PTC
+   committee via the `execution_payload_envelope` gossip topic
+
+### `verify_blinded_envelope_signature`
+
+*Note*: `compute_domain` and `compute_signing_root` are defined in the
+[Gloas consensus specs][gloas-consensus-specs].
+
+```python
+def verify_blinded_envelope_signature(
+    state: BeaconState,
+    signed_envelope: SignedBlindedExecutionPayloadEnvelope,
+    proposer_index: ValidatorIndex,
+) -> bool:
+    validator = state.validators[proposer_index]
+    pubkey = validator.pubkey
+    domain = compute_domain(DOMAIN_BEACON_PROPOSER)
+    signing_root = compute_signing_root(signed_envelope.message, domain)
+    return bls.Verify(pubkey, signing_root, signed_envelope.signature)
+```
+
+### `process_block_and_envelope`
+
+```python
+def process_block_and_envelope(
+    state: BeaconState,
+    builder_bid: BuilderBid,
+    block_and_envelope: BlockAndBlindedEnvelope,
+    execution_payload: ExecutionPayload,
+    execution_requests: ExecutionRequests,
+    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+) -> SignedExecutionPayloadEnvelope:
+    signed_block = block_and_envelope.signed_beacon_block
+    signed_blinded_envelope = block_and_envelope.signed_blinded_envelope
+    blinded_envelope = signed_blinded_envelope.message
+
+    block = signed_block.message
+    proposer_index = block.proposer_index
+
+    # Verify beacon block root matches
+    beacon_block_root = hash_tree_root(block)
+    assert blinded_envelope.beacon_block_root == beacon_block_root
+
+    # Verify the bid in the block matches our bid
+    assert block.body.signed_execution_payload_bid == builder_bid.bid
+
+    # Verify payload root matches
+    assert blinded_envelope.payload_root == hash_tree_root(execution_payload)
+
+    # Verify execution requests root matches
+    assert blinded_envelope.execution_requests_root == hash_tree_root(
+        execution_requests
+    )
+
+    # Verify blob commitments root matches
+    assert blinded_envelope.blob_kzg_commitments_root == hash_tree_root(
+        blob_kzg_commitments
+    )
+
+    # Verify slot matches
+    assert blinded_envelope.slot == block.slot
+
+    # Verify builder index is self-build
+    assert blinded_envelope.builder_index == BUILDER_INDEX_SELF_BUILD
+
+    # Verify blinded envelope signature
+    assert verify_blinded_envelope_signature(
+        state, signed_blinded_envelope, proposer_index
+    )
+
+    # Construct the full execution payload envelope
+    envelope = ExecutionPayloadEnvelope(
+        payload=execution_payload,
+        execution_requests=execution_requests,
+        builder_index=BUILDER_INDEX_SELF_BUILD,
+        beacon_block_root=beacon_block_root,
+        blob_kzg_commitments=blob_kzg_commitments,
+        state_root=blinded_envelope.state_root,
+    )
+
+    # Sign and return
+    return sign_execution_payload_envelope(envelope)
+```
+
+## Constructing a `SignedExecutionPayloadEnvelope`
+
+After receiving and validating the `BlockAndBlindedEnvelope`, the builder
+constructs a `SignedExecutionPayloadEnvelope` by unblinding the
+`BlindedExecutionPayloadEnvelope` with the actual execution payload data.
+
+The specification for constructing a `SignedExecutionPayloadEnvelope` is
+documented in the [Gloas consensus specs][gloas-builder-specs].
+
+The builder MUST broadcast the `SignedExecutionPayloadEnvelope` to the PTC
+committee via the `execution_payload_envelope` gossip topic.
+
+[get-builder-bid-api]: ./../../apis/builder/builder_bid.yaml
+[gloas-builder-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md
+[gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
+[submit-block-and-envelope-api]: ./../../apis/builder/block_and_envelope.yaml

--- a/specs/gloas/unstaked_builder.md
+++ b/specs/gloas/unstaked_builder.md
@@ -108,7 +108,7 @@ commit to the envelope without having access to the full execution payload.
 ```python
 class BlindedExecutionPayloadEnvelope(Container):
     payload_root: Root
-    execution_requests_root: Root
+    execution_requests: ExecutionRequests
     builder_index: BuilderIndex
     beacon_block_root: Root
     slot: Slot

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -1,0 +1,38 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Gloas - Honest Validator](#gloas---honest-validator)
+  - [Introduction](#introduction)
+    - [Block proposal](#block-proposal)
+      - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
+        - [ExecutionPayloadBid](#executionpayloadbid)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Gloas - Honest Validator
+
+
+## Introduction
+
+This document explains how a beacon-chain validator can participate in the external block building market post ePBS. 
+
+Validators request an `ExecutionPayloadBid` from the external builder network to put it in their `SignedBeaconBlock`. 
+The external builder network broadcasts the `SignedExecutionPayloadEnvelope` corresponding to the bid to the PTC commitee. 
+
+### Block proposal
+
+#### Constructing the `BeaconBlockBody`
+
+##### ExecutionPayloadBid
+
+To obtain an execution payload, a block proposer building a block on top of a beacon `state` in a given `slot` must take
+the following actions:
+
+1. Call upstream builder software to get an `ExecutionPayloadBid`.
+2. Assemble a `SignedBeaconBlock` according to the process outlined in the [Gloas specs][https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal] but with
+   the `ExecutionPayloadBid` from the prior step.
+3. The proposer returns the `SignedBeaconBlock` back to the upstream block
+   building software.
+5. The upstream block building software constructs the `SignedExecutionPayloadEnvelope` from the
+   `SignedBlindedExecutionPayloadEnvelope` and broadcasts it to the PTC commitee.

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -23,6 +23,7 @@
     - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
       - [Receiving ExecutionPayloadBid](#receiving-executionpayloadbid)
       - [Receiving ExecutionPayloadBid from Unstaked Builder](#receiving-executionpayloadbid-from-unstaked-builder)
+    - [`process_blinded_execution_payload`](#process_blinded_execution_payload)
     - [`construct_blinded_envelope`](#construct_blinded_envelope)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -73,7 +74,7 @@ class SignedBidRequestAuth(Container):
 ```python
 class BlindedExecutionPayloadEnvelope(Container):
     payload_root: Root
-    execution_requests_root: Root
+    execution_requests: ExecutionRequests
     builder_index: BuilderIndex
     beacon_block_root: Root
     slot: Slot
@@ -297,6 +298,82 @@ of a beacon `state` must take the following actions:
    [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope] by
    unblinding the envelope and broadcasts it to the PTC committee.
 
+### `process_blinded_execution_payload`
+
+```python
+def process_blinded_execution_payload(
+    state: BeaconState,
+    header: ExecutionPayloadHeader,
+    builder_bid: BuilderBid,
+    blinded_envelope: SignedBlindedExecutionPayloadEnvelope,
+) -> None:
+    envelope = blinded_envelope.message
+
+    # Cache latest block header state root
+    previous_state_root = hash_tree_root(state)
+    if state.latest_block_header.state_root == Root():
+        state.latest_block_header.state_root = previous_state_root
+
+    # Verify consistency with the beacon block
+    assert envelope.beacon_block_root == hash_tree_root(state.latest_block_header)
+    assert envelope.slot == state.slot
+
+    # Verify consistency with the committed bid
+    committed_bid = state.latest_execution_payload_bid
+    assert envelope.builder_index == committed_bid.builder_index
+    assert committed_bid.blob_kzg_commitments_root == hash_tree_root(
+        builder_bid.blob_kzg_commitments
+    )
+    assert committed_bid.prev_randao == header.prev_randao
+
+    # Verify consistency with expected withdrawals
+    assert header.withdrawals_root == hash_tree_root(state.payload_expected_withdrawals)
+
+    # Verify the gas_limit
+    assert committed_bid.gas_limit == header.gas_limit
+    # Verify the block hash
+    assert committed_bid.block_hash == header.block_hash
+    # Verify consistency of the parent hash with respect to the previous execution payload
+    assert header.parent_hash == state.latest_block_hash
+    # Verify timestamp
+    assert header.timestamp == compute_time_at_slot(state, state.slot)
+    # Verify commitments are under limit
+    assert (
+        len(builder_bid.blob_kzg_commitments)
+        <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+    )
+    # Verify the execution payload is valid
+    versioned_hashes = [
+        kzg_commitment_to_versioned_hash(commitment)
+        for commitment in builder_bid.blob_kzg_commitments
+    ]
+
+    def for_ops(
+        operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]
+    ) -> None:
+        for operation in operations:
+            fn(state, operation)
+
+    for_ops(builder_bid.execution_requests.deposits, process_deposit_request)
+    for_ops(builder_bid.execution_requests.withdrawals, process_withdrawal_request)
+    for_ops(builder_bid.execution_requests.consolidations, process_consolidation_request)
+
+    # Queue the builder payment
+    payment = state.builder_pending_payments[
+        SLOTS_PER_EPOCH + state.slot % SLOTS_PER_EPOCH
+    ]
+    amount = payment.withdrawal.amount
+    if amount > 0:
+        state.builder_pending_withdrawals.append(payment.withdrawal)
+    state.builder_pending_payments[SLOTS_PER_EPOCH + state.slot % SLOTS_PER_EPOCH] = (
+        BuilderPendingPayment()
+    )
+
+    # Cache the execution payload hash
+    state.execution_payload_availability[state.slot % SLOTS_PER_HISTORICAL_ROOT] = 0b1
+    state.latest_block_hash = header.block_hash
+```
+
 ### `construct_blinded_envelope`
 
 *Note*: `hash_tree_root` and `compute_domain` are defined in the
@@ -318,8 +395,13 @@ def construct_blinded_envelope(
         beacon_block_root=hash_tree_root(block),
         slot=block.slot,
         blob_kzg_commitments_root=hash_tree_root(builder_bid.blob_kzg_commitments),
-        state_root=state.hash_tree_root(),
     )
+
+    process_blinded_execution_payload_envelope(
+        state, builder_bid.header, builder_bid.requests, blinded_envelope
+    )
+
+    blinded_envelope.state_root = state.hash_tree_root()
 
     domain = compute_domain(DOMAIN_BEACON_PROPOSER)
     signing_root = compute_signing_root(blinded_envelope, domain)
@@ -330,6 +412,9 @@ def construct_blinded_envelope(
         signature=signature,
     )
 ```
+
+The BeaconState passed to `construct_blinded_envelope` is the resulting state
+after running `process_blinded_execution_payload`.
 
 [can-builder-cover-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#can_builder_cover_bid
 [get-builder-bid-api]: ./../../apis/builder/builder_bid.yaml

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -1,6 +1,9 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+**Table of Contents** *generated with
+[DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Gloas - Honest Validator](#gloas---honest-validator)
   - [Introduction](#introduction)
@@ -8,20 +11,21 @@
     - [Constructing the `ValidatorRegistrationV2`](#constructing-the-validatorregistrationv2)
     - [Validator Registration dissemination](#validator-registration-dissemination)
   - [Block proposal](#block-proposal)
-      - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
-        - [ExecutionPayloadBid](#executionpayloadbid)
+    - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
+      - [ExecutionPayloadBid](#executionpayloadbid)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Gloas - Honest Validator
 
-
 ## Introduction
 
-This document explains how a beacon-chain validator can participate in the external block building market post ePBS. 
+This document explains how a beacon-chain validator can participate in the
+external block building market post ePBS.
 
-Validators request an `ExecutionPayloadBid` from the external builder network to put it in their `SignedBeaconBlock`. 
-The external builder network broadcasts the `SignedExecutionPayloadEnvelope` corresponding to the bid to the PTC commitee. 
+Validators request an `ExecutionPayloadBid` from the external builder network to
+put it in their `SignedBeaconBlock`. The external builder network broadcasts the
+`SignedExecutionPayloadEnvelope` corresponding to the bid to the PTC committee.
 
 ## Helper
 
@@ -47,28 +51,33 @@ def get_proposer_slots_in_upcoming_epoch(
     return proposer_slots
 ```
 
-## Validator Registrations 
+## Validator Registrations
 
 ### Constructing the `ValidatorRegistrationV2`
 
-To do this, the validator client assembles a [`ValidatorRegistrationV2`][validator-registration-v2] with the following
+To do this, the validator client assembles a
+\[`ValidatorRegistrationV2`\][validator-registration-v2] with the following
 information:
 
-* `fee_recipient`: an execution layer address where fees for the validator should go.
-* `builder_index`: the index of the builder to which this registration is being sent to.
-* `gas_limit`: the value a validator prefers for the execution block gas limit.
-* `validator_index`: the validator's index. Used to identify the beacon chain validator and verify the wrapping signature.
-* `execution_payment_accepted`: whether the proposer is willing to accept a trusted payment from the builder with index 
-  `builder_index`.
-* `proposal_slot`: This is set to the slot in which the validator will be proposing. This can be looked up in the `proposal_lookahead`.
-
+- `fee_recipient`: an execution layer address where fees for the validator
+  should go.
+- `builder_index`: the index of the builder to which this registration is being
+  sent to.
+- `gas_limit`: the value a validator prefers for the execution block gas limit.
+- `validator_index`: the validator's index. Used to identify the beacon chain
+  validator and verify the wrapping signature.
+- `execution_payment_accepted`: whether the proposer is willing to accept a
+  trusted payment from the builder with index `builder_index`.
+- `proposal_slot`: This is set to the slot in which the validator will be
+  proposing. This can be looked up in the `proposal_lookahead`.
 
 ### Validator Registration dissemination
 
-This specification suggests validators re-submit registrations only if they will be proposing in the upcoming epoch(E+1). 
-This is such that we don't send too many validator registrations all at once to builders. 
-Validators run `create_validator_registrations` at every epoch boundary to create validator registrations for all the slots
-they will be proposing in the upcoming epoch.
+This specification suggests validators re-submit registrations only if they will
+be proposing in the upcoming epoch(E+1). This is such that we don't send too
+many validator registrations all at once to builders. Validators run
+`create_validator_registrations` at every epoch boundary to create validator
+registrations for all the slots they will be proposing in the upcoming epoch.
 
 ```python
 def create_validator_registrations(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_index: BuilderIndex, execution_payment_accepted: bool) -> List[ValidatorRegistrationV2]:
@@ -87,19 +96,24 @@ def create_validator_registrations(state: BeaconState, validator_index: Validato
 
   return registrations
 ```
+
 ## Block proposal
 
 #### Constructing the `BeaconBlockBody`
 
 ##### ExecutionPayloadBid
 
-To obtain an execution payload, a block proposer building a block on top of a beacon `state` in a given `slot` must take
-the following actions:
+To obtain an execution payload, a block proposer building a block on top of a
+beacon `state` in a given `slot` must take the following actions:
 
 1. Call upstream builder software to get an `ExecutionPayloadBid`.
-2. Assemble a `SignedBeaconBlock` according to the process outlined in the [Gloas specs][https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal] but with
-   the `ExecutionPayloadBid` from the prior step.
+2. Assemble a `SignedBeaconBlock` according to the process outlined in the
+   \[Gloas
+   specs\][https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal]
+   but with the `ExecutionPayloadBid` from the prior step.
 3. The proposer returns the `SignedBeaconBlock` back to the upstream block
    building software.
-5. The upstream block building software constructs the `SignedExecutionPayloadEnvelope` from the
-   `SignedBlindedExecutionPayloadEnvelope` and broadcasts it to the PTC commitee.
+4. The upstream block building software constructs the
+   `SignedExecutionPayloadEnvelope` from the
+   `SignedBlindedExecutionPayloadEnvelope` and broadcasts it to the PTC
+   committee.

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -7,8 +7,10 @@
   - [Constants](#constants)
   - [Containers](#containers)
     - [New Containers](#new-containers)
-      - [`BidRequestAuth`](#bidrequestauth)
-      - [`SignedBidRequestAuth`](#signedbidrequestauth)
+    - [`BidRequestAuth`](#bidrequestauth)
+    - [`SignedBidRequestAuth`](#signedbidrequestauth)
+    - [`BlindedExecutionPayloadEnvelope`](#blindedexecutionpayloadenvelope)
+    - [`SignedBlindedExecutionPayloadEnvelope`](#signedblindedexecutionpayloadenvelope)
   - [Helper](#helper)
     - [`get_proposer_slots_in_upcoming_epoch`](#get_proposer_slots_in_upcoming_epoch)
   - [Bid Authentication](#bid-authentication)
@@ -20,6 +22,8 @@
   - [Block proposal](#block-proposal)
     - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
       - [Receiving ExecutionPayloadBid](#receiving-executionpayloadbid)
+      - [Receiving ExecutionPayloadBid from Unstaked Builder](#receiving-executionpayloadbid-from-unstaked-builder)
+    - [`construct_blinded_envelope`](#construct_blinded_envelope)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -38,15 +42,14 @@ corresponding to the bid to the PTC committee.
 
 ## Constants
 
-| Name                                      | Value              |
-| ----------------------------------------- | ------------------ |
-| `MAX_SALT_BYTES`                          | `4096`             |
+| Name | Value | | ----------------------------------------- |
+------------------ | | `MAX_SALT_BYTES` | `4096` |
 
 ## Containers
 
 ### New Containers
 
-#### `BidRequestAuth`
+### `BidRequestAuth`
 
 `BidRequestAuth` is used to authenticate requests to get the bid from a builder.
 This is useful so that other builders do not DDOS the builder to get their
@@ -57,11 +60,32 @@ class BidRequestAuth(Container):
     salt: ByteList[MAX_SALT_BYTES]
 ```
 
-#### `SignedBidRequestAuth`
+### `SignedBidRequestAuth`
 
 ```python
 class SignedBidRequestAuth(Container):
     message: BidRequestAuth
+    signature: BLSSignature
+```
+
+### `BlindedExecutionPayloadEnvelope`
+
+```python
+class BlindedExecutionPayloadEnvelope(Container):
+    payload_root: Root
+    execution_requests_root: Root
+    builder_index: BuilderIndex
+    beacon_block_root: Root
+    slot: Slot
+    blob_kzg_commitments_root: Root
+    state_root: Root
+```
+
+### `SignedBlindedExecutionPayloadEnvelope`
+
+```python
+class SignedBlindedExecutionPayloadEnvelope(Container):
+    message: BlindedExecutionPayloadEnvelope
     signature: BLSSignature
 ```
 
@@ -233,13 +257,90 @@ block on top of a beacon `state` must take the following actions:
    [`SignedExecutionPayloadBid`][signed-execution-payload-bid] and broadcasts it
    to the PTC committee.
 
+#### Receiving ExecutionPayloadBid from Unstaked Builder
+
+For unstaked builders, the flow is different. To obtain execution payloads from
+an unstaked builder for a given `slot`, a block proposer building a block on top
+of a beacon `state` must take the following actions:
+
+1. Call the unstaked builder to get a [`SignedBuilderBid`][signed-builder-bid]
+   using the [`getBuilderBid`][get-builder-bid-api] API call. The bid contains:
+
+   - An `ExecutionPayloadHeader`
+   - Blob KZG commitments
+   - Execution requests
+   - A `SignedExecutionPayloadBid` with `builder_index` set to
+     `BUILDER_INDEX_SELF_BUILD`
+
+2. Assemble a `SignedBeaconBlock` according to the process outlined in the
+   [Gloas validator specs][gloas-validator-specs] using the
+   [`SignedExecutionPayloadBid`][signed-execution-payload-bid] from the builder
+   bid.
+
+3. Construct a `SignedBlindedExecutionPayloadEnvelope` by:
+
+   - Setting `beacon_block_root` to
+     `hash_tree_root(signed_beacon_block.message)`
+   - Setting `payload_root` to the root of the execution payload (from header)
+   - Setting `execution_requests_root` to the root of execution requests
+   - Setting `blob_kzg_commitments_root` to the root of blob commitments
+   - Setting `builder_index` to `BUILDER_INDEX_SELF_BUILD`
+   - Setting `slot` to the block's slot
+   - Setting `state_root` to the post-state root
+   - Signing with the proposer's key
+
+4. Submit both the `SignedBeaconBlock` and
+   `SignedBlindedExecutionPayloadEnvelope` to the unstaked builder via the
+   [`submitBlockAndEnvelope`][submit-block-and-envelope-api] API call.
+
+5. The unstaked builder constructs the full
+   [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope] by
+   unblinding the envelope and broadcasts it to the PTC committee.
+
+### `construct_blinded_envelope`
+
+*Note*: `hash_tree_root` and `compute_domain` are defined in the
+[Gloas consensus specs][gloas-consensus-specs].
+
+```python
+def construct_blinded_envelope(
+    state: BeaconState,
+    signed_block: SignedBeaconBlock,
+    builder_bid: BuilderBid,
+    privkey: int,
+) -> SignedBlindedExecutionPayloadEnvelope:
+    block = signed_block.message
+
+    blinded_envelope = BlindedExecutionPayloadEnvelope(
+        payload_root=hash_tree_root(builder_bid.header),
+        execution_requests_root=hash_tree_root(builder_bid.execution_requests),
+        builder_index=BUILDER_INDEX_SELF_BUILD,
+        beacon_block_root=hash_tree_root(block),
+        slot=block.slot,
+        blob_kzg_commitments_root=hash_tree_root(builder_bid.blob_kzg_commitments),
+        state_root=state.hash_tree_root(),
+    )
+
+    domain = compute_domain(DOMAIN_BEACON_PROPOSER)
+    signing_root = compute_signing_root(blinded_envelope, domain)
+    signature = bls.Sign(privkey, signing_root)
+
+    return SignedBlindedExecutionPayloadEnvelope(
+        message=blinded_envelope,
+        signature=signature,
+    )
+```
+
 [can-builder-cover-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#can_builder_cover_bid
+[get-builder-bid-api]: ./../../apis/builder/builder_bid.yaml
 [get-execution-payload-bid-api]: ./../../apis/builder/execution_payload_bid.yaml
 [gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
 [gloas-validator-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal
 [is-active-builder]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#is_active_builder
+[signed-builder-bid]: ./unstaked_builder.md#signedbuilderBid
 [signed-execution-payload-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadbid
 [signed-execution-payload-envelope]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadenvelope
+[submit-block-and-envelope-api]: ./../../apis/builder/block_and_envelope.yaml
 [submit-signed-beacon-block]: ./../../apis/builder/beacon_block.yaml
 [validator-registration-v2]: ./builder.md#validatorregistrationv2
 [verify-execution-payload-bid-signature]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#verify_execution_payload_bid_signature

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -84,10 +84,7 @@ def create_validator_registrations_for_builder(state: BeaconState, validator_ind
     slots = get_proposer_slots_in_lookahead(state, validator_index)
     registrations: List[ValidatorRegistrationsV2] = []
 
-    assert is_builder(state, builder_index)
-    
-    builder = state.builders[builder_index]
-    assert builder.exit_epoch == FAR_FUTURE_EPOCH
+    assert is_active_builder(state, builder_index)
 
     for slot in slots:
       registrations.append(ValidatorRegistrationV2(

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -6,8 +6,14 @@
 
 - [Gloas - Honest Validator](#gloas---honest-validator)
   - [Introduction](#introduction)
+  - [Containers](#containers)
+    - [New Containers](#new-containers)
+      - [`BidRequestAuth`](#bidrequestauth)
+      - [`SignedBidRequestAuth`](#signedbidrequestauth)
   - [Helper](#helper)
     - [`get_proposer_slots_in_upcoming_epoch`](#get_proposer_slots_in_upcoming_epoch)
+  - [Bid Authentication](#bid-authentication)
+    - [Constructing the `BidRequestAuth`](#constructing-the-bidrequestauth)
   - [Validator Registrations](#validator-registrations)
     - [Constructing the `ValidatorRegistrationV2`](#constructing-the-validatorregistrationv2)
     - [Validator Registration dissemination](#validator-registration-dissemination)
@@ -25,9 +31,11 @@
 This document explains how a beacon-chain validator can participate in the
 external block building market with the Builder-API post ePBS.
 
-Validators request an `ExecutionPayloadBid` from the external builder network to
-put it in their `SignedBeaconBlock`. The external builder network broadcasts the
-`SignedExecutionPayloadEnvelope` corresponding to the bid to the PTC committee.
+Validators request a [`SignedExecutionPayloadBid`][signed-execution-payload-bid]
+from the external builder network to put it in their `SignedBeaconBlock`. The
+external builder network broadcasts the
+[`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope]
+corresponding to the bid to the PTC committee.
 
 ## Containers
 
@@ -57,6 +65,9 @@ class SignedBidRequestAuth(Container):
 ## Helper
 
 ### `get_proposer_slots_in_upcoming_epoch`
+
+*Note*: `compute_start_slot_at_epoch` and `get_current_epoch` are defined in the
+[Gloas consensus specs][gloas-consensus-specs].
 
 ```python
 def get_proposer_slots_in_upcoming_epoch(
@@ -90,15 +101,16 @@ To construct the `BidRequestAuth`, we need to fill the following information:
 - `proposal_slot`: The slot at which the proposer is building a block.
 
 The validator constructs the `SignedBidRequestAuth` by signing the
-`BidRequestAuth`. It sends the `SignedBidRequestAuth` as a header along with the
-request to get the bid.
+`BidRequestAuth`. It sends the `SignedBidRequestAuth` in the request body along
+with the request to get the bid in the
+[`getExecutionPayloadBid`][get-execution-payload-bid-api] API call.
 
 ## Validator Registrations
 
 ### Constructing the `ValidatorRegistrationV2`
 
 To do this, the validator client assembles a
-\[`ValidatorRegistrationV2`\][validator-registration-v2] with the following
+[`ValidatorRegistrationV2`][validator-registration-v2] with the following
 information:
 
 - `fee_recipient`: An execution layer address where fees for the validator
@@ -122,25 +134,33 @@ registrations for all the slots they will be proposing in the upcoming epoch.
 ```python
 def create_validator_registrations(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_preferences: BuilderPreferences) -> List[ValidatorRegistrationV2]:
     slots = get_proposer_slots_in_upcoming_epoch(state, validator_index)
-    registrations: List[ValidatorRegistrationsV2] = []
+    registrations: List[ValidatorRegistrationV2] = []
 
     for slot in slots:
-      registrations.append(ValidatorRegistrationV2(
-        fee_recipient=fee_recipient,
-        gas_limit=gas_limit,
-        validator_index=validator_index
-        builder_preferences=builder_preferences,
-        proposal_slot=slot
-      ))
+        registrations.append(ValidatorRegistrationV2(
+            fee_recipient=fee_recipient,
+            gas_limit=gas_limit,
+            validator_index=validator_index,
+            builder_preferences=builder_preferences,
+            proposal_slot=slot
+        ))
 
-  return registrations
+    return registrations
 ```
 
 ## Validating a `SignedExecutionPayloadBid`
 
-When the proposer receives a `SignedExecutionPayloadBid` from a builder, it can
-validate the bid using `validate_bid`. It can discard the bid if the conditions
-are not satisfied.
+When the proposer receives a
+[`SignedExecutionPayloadBid`][signed-execution-payload-bid] from a builder, it
+can validate the bid using `validate_bid`. It can discard the bid if the
+conditions are not satisfied.
+
+*Note*: `hash_tree_root`, `get_randao_mix`, and `get_current_epoch` are defined
+in the [Gloas consensus specs][gloas-consensus-specs]. The predicates
+[`is_active_builder`][is-active-builder],
+[`can_builder_cover_bid`][can-builder-cover-bid], and
+[`verify_execution_payload_bid_signature`][verify-execution-payload-bid-signature]
+are also defined in the consensus specs.
 
 ```python
 def validate_bid(
@@ -170,18 +190,33 @@ def validate_bid(
 To obtain an execution payload, a block proposer building a block on top of a
 beacon `state` in a given `slot` must take the following actions:
 
-1. Call upstream builder software to get an `ExecutionPayloadBid`. The validator
-   is required to send the `SignedBidRequestAuth` in the request body in order
-   to authenticate the request to the builder. If a builder has multiple builder
-   indices associated with them, the validator will have to call the upstream
-   builder software each time for each builder index.
+1. Call upstream builder software to get a
+   [`SignedExecutionPayloadBid`][signed-execution-payload-bid] using the
+   [`getExecutionPayloadBid`][get-execution-payload-bid-api] API call. The
+   validator is required to send the `SignedBidRequestAuth` in the request body
+   in order to authenticate the request to the builder. If a builder has
+   multiple builder indices associated with them, the validator will have to
+   call the upstream builder software each time for each builder index.
 2. Assemble a `SignedBeaconBlock` according to the process outlined in the
-   \[Gloas
-   specs\][https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal]
-   but with the best `ExecutionPayloadBid` from the prior step.
+   [Gloas validator specs][gloas-validator-specs] but with the best
+   [`SignedExecutionPayloadBid`][signed-execution-payload-bid] from the prior
+   step.
 3. The proposer returns the `SignedBeaconBlock` back to the upstream block
-   building software.
+   building software via
+   [`submitSignedBeaconBlock`][submit-signed-beacon-block] API call.
 4. The upstream block building software constructs the
-   `SignedExecutionPayloadEnvelope` from the
-   `SignedBlindedExecutionPayloadEnvelope` and broadcasts it to the PTC
-   committee.
+   [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope]
+   corresponding to the
+   [`SignedExecutionPayloadBid`][signed-execution-payload-bid] and broadcasts it
+   to the PTC committee.
+
+[can-builder-cover-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#can_builder_cover_bid
+[get-execution-payload-bid-api]: ./../../apis/builder/execution_payload_bid.yaml
+[gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
+[gloas-validator-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal
+[is-active-builder]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#is_active_builder
+[submit-signed-beacon-block]: ./../../apis/builder/beacon_block.yaml
+[signed-execution-payload-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadbid
+[signed-execution-payload-envelope]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadenvelope
+[validator-registration-v2]: ./builder.md#validatorregistrationv2
+[verify-execution-payload-bid-signature]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#verify_execution_payload_bid_signature

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -23,6 +23,30 @@ This document explains how a beacon-chain validator can participate in the exter
 Validators request an `ExecutionPayloadBid` from the external builder network to put it in their `SignedBeaconBlock`. 
 The external builder network broadcasts the `SignedExecutionPayloadEnvelope` corresponding to the bid to the PTC commitee. 
 
+## Helper
+
+### `get_proposer_slots_in_upcoming_epoch`
+
+```python
+def get_proposer_slots_in_upcoming_epoch(
+    state: BeaconState, 
+    validator_index: ValidatorIndex
+) -> List[Slot]:
+    """
+    Return all slots where validator_index is the proposer within the lookahead window in the next epoch.
+    """
+    proposer_slots = []
+    current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
+    next_epoch_proposer_lookahead = state.proposer_lookahead[SLOTS_PER_EPOCH:]
+    
+    for i, proposer_index in enumerate(next_epoch_proposer_lookahead):
+        if proposer_index == validator_index:
+            slot = current_epoch_start_slot + SLOTS_PER_EPOCH + i
+            proposer_slots.append(slot)
+    
+    return proposer_slots
+```
+
 ## Validator Registrations 
 
 ### Constructing the `ValidatorRegistrationV2`
@@ -31,32 +55,38 @@ To do this, the validator client assembles a [`ValidatorRegistrationV2`][validat
 information:
 
 * `fee_recipient`: an execution layer address where fees for the validator should go.
-* `builder_pubkey`: the pubkey of the builder to which this registration is being sent to.
+* `builder_index`: the index of the builder to which this registration is being sent to.
 * `gas_limit`: the value a validator prefers for the execution block gas limit.
-* `timestamp`: a recent timestamp later than any previously constructed `ValidatorRegistrationV1`.
-  Builders use this timestamp as a form of anti-DoS and to sequence registrations.
-* `pubkey`: the validator's public key. Used to identify the beacon chain validator and verify the wrapping signature.
-* `can_accept_trusted_payment`: whether the proposer is willing to accept a trusted payment from the builder with pubkey 
-  `builder_pubkey`.
-* `proposal_epoch`: This is set to `get_current_epoch(state) + 1`.
+* `validator_index`: the validator's index. Used to identify the beacon chain validator and verify the wrapping signature.
+* `execution_payment_accepted`: whether the proposer is willing to accept a trusted payment from the builder with index 
+  `builder_index`.
+* `proposal_slot`: This is set to the slot in which the validator will be proposing. This can be looked up in the `proposal_lookahead`.
 
 
 ### Validator Registration dissemination
 
 This specification suggests validators re-submit registrations only if they will be proposing in the upcoming epoch(E+1). 
-This is to avoid sending a lot of `ValidatorRegistrations` every epoch. This can potentially help reduce the load 
-Validators are expected to perform this check at every epoch boundary. Validators can send their registrations even though
-they won't be proposing in the upcoming epoch.
+This is such that we don't send too many validator registrations all at once to builders. 
+Validators run `create_validator_registrations` at every epoch boundary to create validator registrations for all the slots
+they will be proposing in the upcoming epoch.
 
 ```python
-def is_next_epoch_proposer(state: BeaconState, validator_index: ValidatorIndex) -> bool:
-    """
-    Check if ``validator_index`` is scheduled to propose in the next epoch.
-    """
-    next_epoch_proposers = state.proposer_lookahead[SLOTS_PER_EPOCH:]
-    return validator_index in next_epoch_proposers
-```
+def create_validator_registrations(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_index: BuilderIndex, execution_payment_accepted: bool) -> List[ValidatorRegistrationV2]:
+    slots = get_proposer_slots_in_lookahead(state, validator_index)
+    registrations: List[ValidatorRegistrationsV2] = []
 
+    for slot in slots:
+      registrations.append(ValidatorRegistrationV2(
+        fee_recipient=fee_recipient,
+        builder_index=builder_index,
+        gas_limit=gas_limit,
+        validator_index=validator_index
+        execution_payment_accepted=execution_payment_accepted,
+        proposal_slot=slot
+      ))
+
+  return registrations
+```
 ## Block proposal
 
 #### Constructing the `BeaconBlockBody`

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -118,8 +118,8 @@ information:
 - `gas_limit`: The value a validator prefers for the execution block gas limit.
 - `validator_index`: The validator's index. Used to identify the beacon chain
   validator and verify the wrapping signature.
-- `execution_payment_accepted`: Whether the proposer is willing to accept a
-  trusted payment from the builder with index `builder_index`.
+- `max_trusted_bid`: The amount(in Gwei) the proposer is willing to accept as a
+  trusted execution layer payment from the builder.
 - `proposal_slot`: This is set to the slot in which the validator will be
   proposing. This can be looked up in `state.proposal_lookahead`.
 
@@ -179,8 +179,7 @@ def validate_bid(
     assert bid.parent_block_root == hash_tree_root(state.latest_block_header)
     assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
 
-    if not reg.message.builder_preferences.execution_payment_accepted:
-      assert bid.execution_payment == 0
+    assert bid.execution_payment <= reg.message.builder_preferences.max_trusted_bid
 
     if bid.value > 0:
         assert can_builder_cover_bid(state, bid.builder_index, signed_bid.value)

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -101,8 +101,6 @@ To do this, the validator client assembles a
 \[`ValidatorRegistrationV2`\][validator-registration-v2] with the following
 information:
 
-- `builder_index`: The index of the builder to which the validator is submitting
-  the registration.
 - `fee_recipient`: An execution layer address where fees for the validator
   should go.
 - `gas_limit`: The value a validator prefers for the execution block gas limit.
@@ -122,17 +120,14 @@ many validator registrations all at once to builders. Validators run
 registrations for all the slots they will be proposing in the upcoming epoch.
 
 ```python
-def create_validator_registrations_for_builder(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_index: BuilderIndex, builder_preferences: BuilderPreferences) -> List[ValidatorRegistrationV2]:
+def create_validator_registrations(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_preferences: BuilderPreferences) -> List[ValidatorRegistrationV2]:
     slots = get_proposer_slots_in_lookahead(state, validator_index)
     registrations: List[ValidatorRegistrationsV2] = []
-
-    assert is_active_builder(state, builder_index)
 
     for slot in slots:
       registrations.append(ValidatorRegistrationV2(
         fee_recipient=fee_recipient,
         gas_limit=gas_limit,
-        builder_index=builder_index,
         validator_index=validator_index
         builder_preferences=builder_preferences,
         proposal_slot=slot
@@ -176,9 +171,10 @@ To obtain an execution payload, a block proposer building a block on top of a
 beacon `state` in a given `slot` must take the following actions:
 
 1. Call upstream builder software to get an `ExecutionPayloadBid`. The validator
-   is required to send the `SignedBidRequestAuth` in the request body in order to
-   authenticate the request to the builder. If a builder has multiple builder indices associated with 
-   them, the validator will have to call the upstream builder software each time for each builder index. 
+   is required to send the `SignedBidRequestAuth` in the request body in order
+   to authenticate the request to the builder. If a builder has multiple builder
+   indices associated with them, the validator will have to call the upstream
+   builder software each time for each builder index.
 2. Assemble a `SignedBeaconBlock` according to the process outlined in the
    \[Gloas
    specs\][https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal]

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -121,7 +121,7 @@ registrations for all the slots they will be proposing in the upcoming epoch.
 
 ```python
 def create_validator_registrations(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_preferences: BuilderPreferences) -> List[ValidatorRegistrationV2]:
-    slots = get_proposer_slots_in_lookahead(state, validator_index)
+    slots = get_proposer_slots_in_upcoming_epoch(state, validator_index)
     registrations: List[ValidatorRegistrationsV2] = []
 
     for slot in slots:

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -1,7 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Honest Validator](#gloas---honest-validator)
@@ -14,7 +12,7 @@
   - [Validating a `SignedExecutionPayloadBid`](#validating-a-signedexecutionpayloadbid)
   - [Block proposal](#block-proposal)
     - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
-      - [ExecutionPayloadBid](#executionpayloadbid)
+      - [Receiving ExecutionPayloadBid](#receiving-executionpayloadbid)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -39,7 +39,7 @@ corresponding to the bid to the PTC committee.
 ## Constants
 
 | Name | Value | | -------------------------------- | -------------------| |
-`MAX_BUILDER_INDICES` | `2**64 - 1`|
+`MAX_SALT_BYTES` | `4096` |
 
 ## Containers
 
@@ -53,7 +53,7 @@ latest bid.
 
 ```python
 class BidRequestAuth(Container):
-    builder_indices: List[BuilderIndex, MAX_BUILDER_INDICES]
+    salt: ByteList[MAX_SALT_BYTES]
 ```
 
 #### `SignedBidRequestAuth`
@@ -96,9 +96,9 @@ def get_proposer_slots_in_upcoming_epoch(
 
 To construct the `BidRequestAuth`, we need to fill the following information:
 
-- `builder_indices`: These are the builder indices corresponding to the builder
-  from whom we are fetching the bid. These indices will be known by the
-  validators when they whitelist the builder.
+- `salt`: This is a 4kB salt which has to be specific to each whitelisted
+  builder. The spec requires the proposer to set it to the URL provided by the
+  whitelisted builder.
 
 The validator constructs the `SignedBidRequestAuth` by signing the
 `BidRequestAuth`. It sends the `SignedBidRequestAuth` in the request body along
@@ -175,12 +175,9 @@ def validate_bid(
     state: BeaconState,
     reg: SignedValidatorRegistrationV2,
     signed_bid: SignedExecutionPayloadBid,
-    bid_request_auth: SignedBidRequestAuth,
     fee_recipient: ExecutionAddress,
 ) -> bool:
     bid = signed_bid.message
-
-    assert bid.builder_index in bid_request_auth.message.builder_indices
 
     builder = state.builders[bid.builder_index]
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -164,22 +164,39 @@ are also defined in the consensus specs.
 
 ```python
 def validate_bid(
-    state: BeaconState, signed_bid: SignedExecutionPayloadBid, fee_recipient: ExecutionAddress
+    state: BeaconState, reg: SignedValidatorRegistrationV2, bid: SignedExecutionPayloadBid, bid_request_auth: SignedBidRequestAuth, fee_recipient: ExecutionAddress
 ) -> bool:
-    builder = state.builders[signed_bid.builder_index]
+    bid = bid.message
+
+    assert bid.builder_index == bid_request_auth.message.builder_index
+
+    builder = state.builders[bid.builder_index]
     
     assert is_active_builder(state, builder)
-    assert signed_bid.slot == state.slot
-    assert signed_bid.fee_recipient == fee_recipient
-    assert signed_bid.parent_block_hash == state.latest_block_hash
-    assert signed_bid.parent_block_root == hash_tree_root(state.latest_block_header)
-    assert signed_bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
+    assert bid.slot == state.slot
+    assert bid.fee_recipient == fee_recipient
+    assert bid.parent_block_hash == state.latest_block_hash
+    assert bid.parent_block_root == hash_tree_root(state.latest_block_header)
+    assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
 
-    if signed_bid.value > 0:
-        assert can_builder_cover_bid(state, signed_bid.builder_index, signed_bid.value)
+    if not reg.message.builder_preferences.execution_payment_accepted:
+      assert bid.execution_payment == 0
 
-    return verify_execution_payload_bid_signature(state, signed_bid)
+    if bid.value > 0:
+        assert can_builder_cover_bid(state, bid.builder_index, signed_bid.value)
+
+    return verify_execution_payload_bid_signature(state, bid)
 ```
+
+Note that, the fee recipient specified in `bid.fee_recipient` does not
+necessarily correspond to the fee recipient of the execution payload. Even if a
+builder pays the validator via execution layer payments, we require that the
+bid's fee recipient matches the validators expected fee recipient and not the
+builder's fee recipient.
+
+To express per-builder preferences we need validators to remember which
+registration they have sent to the builder, so that they can validate whether
+the bid conforms to the preferences expressed by the validators.
 
 ## Block proposal
 
@@ -202,8 +219,8 @@ beacon `state` in a given `slot` must take the following actions:
    [`SignedExecutionPayloadBid`][signed-execution-payload-bid] from the prior
    step.
 3. The proposer returns the `SignedBeaconBlock` back to the upstream block
-   building software via
-   [`submitSignedBeaconBlock`][submit-signed-beacon-block] API call.
+   building software via [`submitSignedBeaconBlock`][submit-signed-beacon-block]
+   API call.
 4. The upstream block building software constructs the
    [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope]
    corresponding to the
@@ -215,8 +232,8 @@ beacon `state` in a given `slot` must take the following actions:
 [gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
 [gloas-validator-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal
 [is-active-builder]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#is_active_builder
-[submit-signed-beacon-block]: ./../../apis/builder/beacon_block.yaml
 [signed-execution-payload-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadbid
 [signed-execution-payload-envelope]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#signedexecutionpayloadenvelope
+[submit-signed-beacon-block]: ./../../apis/builder/beacon_block.yaml
 [validator-registration-v2]: ./builder.md#validatorregistrationv2
 [verify-execution-payload-bid-signature]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#verify_execution_payload_bid_signature

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -1,5 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Honest Validator](#gloas---honest-validator)
@@ -110,13 +112,13 @@ def validate_bid(
     state: BeaconState, signed_bid: SignedExecutionPayloadBid, fee_recipient: ExecutionAddress
 ) -> bool:
     builder = state.builders[signed_bid.builder_index]
-
+    
+    assert is_active_builder(state, builder)
     assert signed_bid.slot == state.slot
     assert signed_bid.fee_recipient == fee_recipient
     assert signed_bid.parent_block_hash == state.latest_block_hash
     assert signed_bid.parent_block_root == hash_tree_root(state.latest_block_header)
     assert signed_bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
-    assert is_builder(state, builder.pubkey)
 
     if signed_bid.value > 0:
         assert can_builder_cover_bid(state, signed_bid.builder_index, signed_bid.value)

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -4,6 +4,7 @@
 
 - [Gloas - Honest Validator](#gloas---honest-validator)
   - [Introduction](#introduction)
+  - [Constants](#constants)
   - [Containers](#containers)
     - [New Containers](#new-containers)
       - [`BidRequestAuth`](#bidrequestauth)
@@ -35,6 +36,11 @@ external builder network broadcasts the
 [`SignedExecutionPayloadEnvelope`][signed-execution-payload-envelope]
 corresponding to the bid to the PTC committee.
 
+## Constants
+
+| Name | Value | | -------------------------------- | -------------------| |
+`MAX_BUILDER_INDICES` | `uint64('2**64-1')`|
+
 ## Containers
 
 ### New Containers
@@ -47,9 +53,7 @@ latest bid.
 
 ```python
 class BidRequestAuth(Container):
-    builder_index: BuilderIndex
-    validator_index: ValidatorIndex
-    proposer_slot: Slot
+    builder_indices: List[BuilderIndex, MAX_BUILDER_INDICES]
 ```
 
 #### `SignedBidRequestAuth`
@@ -176,7 +180,7 @@ def validate_bid(
 ) -> bool:
     bid = bid.message
 
-    assert bid.builder_index == bid_request_auth.message.builder_index
+    assert bid.builder_index in bid_request_auth.message.builder_indices
 
     builder = state.builders[bid.builder_index]
 
@@ -190,7 +194,7 @@ def validate_bid(
     assert bid.execution_payment <= reg.message.builder_preferences.max_trusted_bid
 
     if bid.value > 0:
-        assert can_builder_cover_bid(state, bid.builder_index, signed_bid.value)
+        assert can_builder_cover_bid(state, bid.builder_index, bid.value)
 
     return verify_execution_payload_bid_signature(state, bid)
 ```

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -2,8 +2,6 @@
 
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 - [Gloas - Honest Validator](#gloas---honest-validator)
   - [Introduction](#introduction)
   - [Containers](#containers)
@@ -44,22 +42,22 @@ corresponding to the bid to the PTC committee.
 #### `BidRequestAuth`
 
 `BidRequestAuth` is used to authenticate requests to get the bid from a builder.
-This is useful so that other builders don't DDOS the builder to get their latest
-bid.
+This is useful so that other builders do not DDOS the builder to get their
+latest bid.
 
 ```python
 class BidRequestAuth(Container):
-  builder_index: BuilderIndex
-  validator_index: ValidatorIndex
-  proposer_slot: Slot
+    builder_index: BuilderIndex
+    validator_index: ValidatorIndex
+    proposer_slot: Slot
 ```
 
 #### `SignedBidRequestAuth`
 
 ```python
 class SignedBidRequestAuth(Container):
-  message: BidRequestAuth
-  signature: BLSSignature
+    message: BidRequestAuth
+    signature: BLSSignature
 ```
 
 ## Helper
@@ -71,8 +69,7 @@ class SignedBidRequestAuth(Container):
 
 ```python
 def get_proposer_slots_in_upcoming_epoch(
-    state: BeaconState, 
-    validator_index: ValidatorIndex
+    state: BeaconState, validator_index: ValidatorIndex
 ) -> List[Slot]:
     """
     Return all slots where validator_index is the proposer within the lookahead window in the next epoch.
@@ -80,12 +77,12 @@ def get_proposer_slots_in_upcoming_epoch(
     proposer_slots = []
     current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
     next_epoch_proposer_lookahead = state.proposer_lookahead[SLOTS_PER_EPOCH:]
-    
+
     for offset, proposer_index in enumerate(next_epoch_proposer_lookahead):
         if proposer_index == validator_index:
             slot = current_epoch_start_slot + SLOTS_PER_EPOCH + offset
             proposer_slots.append(slot)
-    
+
     return proposer_slots
 ```
 
@@ -126,24 +123,31 @@ information:
 ### Validator Registration dissemination
 
 This specification suggests validators re-submit registrations only if they will
-be proposing in the upcoming epoch(E+1). This is such that we don't send too
+be proposing in the upcoming epoch(E+1). This is such that we do not send too
 many validator registrations all at once to builders. Validators run
 `create_validator_registrations` at every epoch boundary to create validator
 registrations for all the slots they will be proposing in the upcoming epoch.
 
 ```python
-def create_validator_registrations(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_preferences: BuilderPreferences) -> List[ValidatorRegistrationV2]:
+def create_validator_registrations(
+    state: BeaconState,
+    validator_index: ValidatorIndex,
+    gas_limit: uint64,
+    builder_preferences: BuilderPreferences,
+) -> List[ValidatorRegistrationV2]:
     slots = get_proposer_slots_in_upcoming_epoch(state, validator_index)
     registrations: List[ValidatorRegistrationV2] = []
 
     for slot in slots:
-        registrations.append(ValidatorRegistrationV2(
-            fee_recipient=fee_recipient,
-            gas_limit=gas_limit,
-            validator_index=validator_index,
-            builder_preferences=builder_preferences,
-            proposal_slot=slot
-        ))
+        registrations.append(
+            ValidatorRegistrationV2(
+                fee_recipient=fee_recipient,
+                gas_limit=gas_limit,
+                validator_index=validator_index,
+                builder_preferences=builder_preferences,
+                proposal_slot=slot,
+            )
+        )
 
     return registrations
 ```
@@ -164,14 +168,18 @@ are also defined in the consensus specs.
 
 ```python
 def validate_bid(
-    state: BeaconState, reg: SignedValidatorRegistrationV2, bid: SignedExecutionPayloadBid, bid_request_auth: SignedBidRequestAuth, fee_recipient: ExecutionAddress
+    state: BeaconState,
+    reg: SignedValidatorRegistrationV2,
+    bid: SignedExecutionPayloadBid,
+    bid_request_auth: SignedBidRequestAuth,
+    fee_recipient: ExecutionAddress,
 ) -> bool:
     bid = bid.message
 
     assert bid.builder_index == bid_request_auth.message.builder_index
 
     builder = state.builders[bid.builder_index]
-    
+
     assert is_active_builder(state, builder)
     assert bid.slot == state.slot
     assert bid.fee_recipient == fee_recipient

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -39,7 +39,7 @@ corresponding to the bid to the PTC committee.
 ## Constants
 
 | Name | Value | | -------------------------------- | -------------------| |
-`MAX_BUILDER_INDICES` | `uint64('2**64-1')`|
+`MAX_BUILDER_INDICES` | `2**64 - 1`|
 
 ## Containers
 
@@ -96,10 +96,9 @@ def get_proposer_slots_in_upcoming_epoch(
 
 To construct the `BidRequestAuth`, we need to fill the following information:
 
-- `builder_index`: This builder index for which the validator is sending a
-  request to get the bid.
-- `validator_index`: The proposer's validator index.
-- `proposal_slot`: The slot at which the proposer is building a block.
+- `builder_indices`: These are the builder indices corresponding to the builder
+  from whom we are fetching the bid. These indices will be known by the
+  validators when they whitelist the builder.
 
 The validator constructs the `SignedBidRequestAuth` by signing the
 `BidRequestAuth`. It sends the `SignedBidRequestAuth` in the request body along
@@ -138,6 +137,7 @@ def create_validator_registrations(
     validator_index: ValidatorIndex,
     gas_limit: uint64,
     builder_preferences: BuilderPreferences,
+    fee_recipient: ExecutionAddress,
 ) -> List[ValidatorRegistrationV2]:
     slots = get_proposer_slots_in_upcoming_epoch(state, validator_index)
     registrations: List[ValidatorRegistrationV2] = []
@@ -174,11 +174,11 @@ are also defined in the consensus specs.
 def validate_bid(
     state: BeaconState,
     reg: SignedValidatorRegistrationV2,
-    bid: SignedExecutionPayloadBid,
+    signed_bid: SignedExecutionPayloadBid,
     bid_request_auth: SignedBidRequestAuth,
     fee_recipient: ExecutionAddress,
 ) -> bool:
-    bid = bid.message
+    bid = signed_bid.message
 
     assert bid.builder_index in bid_request_auth.message.builder_indices
 
@@ -196,7 +196,7 @@ def validate_bid(
     if bid.value > 0:
         assert can_builder_cover_bid(state, bid.builder_index, bid.value)
 
-    return verify_execution_payload_bid_signature(state, bid)
+    return verify_execution_payload_bid_signature(state, signed_bid)
 ```
 
 Note that, the fee recipient specified in `bid.fee_recipient` does not
@@ -215,16 +215,14 @@ the bid conforms to the preferences expressed by the validators.
 
 #### Receiving ExecutionPayloadBid
 
-To obtain an execution payload, a block proposer building a block on top of a
-beacon `state` in a given `slot` must take the following actions:
+To obtain execution payloads for a given `slot`, a block proposer building a
+block on top of a beacon `state` must take the following actions:
 
 1. Call upstream builder software to get a
    [`SignedExecutionPayloadBid`][signed-execution-payload-bid] using the
    [`getExecutionPayloadBid`][get-execution-payload-bid-api] API call. The
    validator is required to send the `SignedBidRequestAuth` in the request body
-   in order to authenticate the request to the builder. If a builder has
-   multiple builder indices associated with them, the validator will have to
-   call the upstream builder software each time for each builder index.
+   in order to authenticate the request to the builder.
 2. Assemble a `SignedBeaconBlock` according to the process outlined in the
    [Gloas validator specs][gloas-validator-specs] but with the best
    [`SignedExecutionPayloadBid`][signed-execution-payload-bid] from the prior

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -4,7 +4,10 @@
 
 - [Gloas - Honest Validator](#gloas---honest-validator)
   - [Introduction](#introduction)
-    - [Block proposal](#block-proposal)
+  - [Validator Registrations](#validator-registrations)
+    - [Constructing the `ValidatorRegistrationV2`](#constructing-the-validatorregistrationv2)
+    - [Validator Registration dissemination](#validator-registration-dissemination)
+  - [Block proposal](#block-proposal)
       - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
         - [ExecutionPayloadBid](#executionpayloadbid)
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -122,7 +122,7 @@ information:
 - `max_trusted_bid`: The amount(in Gwei) the proposer is willing to accept as a
   trusted execution layer payment from the builder.
 - `proposal_slot`: This is set to the slot in which the validator will be
-  proposing. This can be looked up in `state.proposal_lookahead`.
+  proposing. This can be looked up in `state.proposer_lookahead`.
 
 ### Validator Registration dissemination
 
@@ -180,14 +180,13 @@ def validate_bid(
 ) -> bool:
     bid = signed_bid.message
 
-    builder = state.builders[bid.builder_index]
-
-    assert is_active_builder(state, builder)
+    assert is_active_builder(state, bid.builder_index)
     assert bid.slot == state.slot
     assert bid.fee_recipient == fee_recipient
     assert bid.parent_block_hash == state.latest_block_hash
     assert bid.parent_block_root == hash_tree_root(state.latest_block_header)
     assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
+    assert bid.gas_limit <= reg.message.gas_limit
 
     assert bid.execution_payment <= reg.message.builder_preferences.max_trusted_bid
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -1,5 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Honest Validator](#gloas---honest-validator)
@@ -11,8 +13,8 @@
     - [Validator Registration dissemination](#validator-registration-dissemination)
   - [Validating a `SignedExecutionPayloadBid`](#validating-a-signedexecutionpayloadbid)
   - [Block proposal](#block-proposal)
-      - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
-        - [ExecutionPayloadBid](#executionpayloadbid)
+    - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
+      - [ExecutionPayloadBid](#executionpayloadbid)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -43,9 +45,9 @@ def get_proposer_slots_in_upcoming_epoch(
     current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
     next_epoch_proposer_lookahead = state.proposer_lookahead[SLOTS_PER_EPOCH:]
     
-    for i, proposer_index in enumerate(next_epoch_proposer_lookahead):
+    for offset, proposer_index in enumerate(next_epoch_proposer_lookahead):
         if proposer_index == validator_index:
-            slot = current_epoch_start_slot + SLOTS_PER_EPOCH + i
+            slot = current_epoch_start_slot + SLOTS_PER_EPOCH + offset
             proposer_slots.append(slot)
     
     return proposer_slots
@@ -80,9 +82,14 @@ many validator registrations all at once to builders. Validators run
 registrations for all the slots they will be proposing in the upcoming epoch.
 
 ```python
-def create_validator_registrations(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_index: BuilderIndex, execution_payment_accepted: bool) -> List[ValidatorRegistrationV2]:
+def create_validator_registrations_for_builder(state: BeaconState, validator_index: ValidatorIndex, gas_limit: uint64, builder_index: BuilderIndex, builder_preferences: BuilderPreferences) -> List[ValidatorRegistrationV2]:
     slots = get_proposer_slots_in_lookahead(state, validator_index)
     registrations: List[ValidatorRegistrationsV2] = []
+
+    assert is_builder(state, builder_index)
+    
+    builder = state.builders[builder_index]
+    assert builder.exit_epoch == FAR_FUTURE_EPOCH
 
     for slot in slots:
       registrations.append(ValidatorRegistrationV2(
@@ -90,7 +97,7 @@ def create_validator_registrations(state: BeaconState, validator_index: Validato
         builder_index=builder_index,
         gas_limit=gas_limit,
         validator_index=validator_index
-        execution_payment_accepted=execution_payment_accepted,
+        builder_preferences=builder_preferences,
         proposal_slot=slot
       ))
 
@@ -126,7 +133,7 @@ def validate_bid(
 
 ### Constructing the `BeaconBlockBody`
 
-#### Recieving ExecutionPayloadBid
+#### Receiving ExecutionPayloadBid
 
 To obtain an execution payload, a block proposer building a block on top of a
 beacon `state` in a given `slot` must take the following actions:

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -23,11 +23,36 @@
 ## Introduction
 
 This document explains how a beacon-chain validator can participate in the
-external block building market post ePBS.
+external block building market with the Builder-API post ePBS.
 
 Validators request an `ExecutionPayloadBid` from the external builder network to
 put it in their `SignedBeaconBlock`. The external builder network broadcasts the
 `SignedExecutionPayloadEnvelope` corresponding to the bid to the PTC committee.
+
+## Containers
+
+### New Containers
+
+#### `BidRequestAuth`
+
+`BidRequestAuth` is used to authenticate requests to get the bid from a builder.
+This is useful so that other builders don't DDOS the builder to get their latest
+bid.
+
+```python
+class BidRequestAuth(Container):
+  builder_index: BuilderIndex
+  validator_index: ValidatorIndex
+  proposer_slot: Slot
+```
+
+#### `SignedBidRequestAuth`
+
+```python
+class SignedBidRequestAuth(Container):
+  message: BidRequestAuth
+  signature: BLSSignature
+```
 
 ## Helper
 
@@ -53,6 +78,21 @@ def get_proposer_slots_in_upcoming_epoch(
     return proposer_slots
 ```
 
+## Bid Authentication
+
+### Constructing the `BidRequestAuth`
+
+To construct the `BidRequestAuth`, we need to fill the following information:
+
+- `builder_index`: This builder index for which the validator is sending a
+  request to get the bid.
+- `validator_index`: The proposer's validator index.
+- `proposal_slot`: The slot at which the proposer is building a block.
+
+The validator constructs the `SignedBidRequestAuth` by signing the
+`BidRequestAuth`. It sends the `SignedBidRequestAuth` as a header along with the
+request to get the bid.
+
 ## Validator Registrations
 
 ### Constructing the `ValidatorRegistrationV2`
@@ -61,17 +101,17 @@ To do this, the validator client assembles a
 \[`ValidatorRegistrationV2`\][validator-registration-v2] with the following
 information:
 
-- `fee_recipient`: an execution layer address where fees for the validator
+- `builder_index`: The index of the builder to which the validator is submitting
+  the registration.
+- `fee_recipient`: An execution layer address where fees for the validator
   should go.
-- `builder_index`: the index of the builder to which this registration is being
-  sent to.
-- `gas_limit`: the value a validator prefers for the execution block gas limit.
-- `validator_index`: the validator's index. Used to identify the beacon chain
+- `gas_limit`: The value a validator prefers for the execution block gas limit.
+- `validator_index`: The validator's index. Used to identify the beacon chain
   validator and verify the wrapping signature.
-- `execution_payment_accepted`: whether the proposer is willing to accept a
+- `execution_payment_accepted`: Whether the proposer is willing to accept a
   trusted payment from the builder with index `builder_index`.
 - `proposal_slot`: This is set to the slot in which the validator will be
-  proposing. This can be looked up in the `proposal_lookahead`.
+  proposing. This can be looked up in `state.proposal_lookahead`.
 
 ### Validator Registration dissemination
 
@@ -91,8 +131,8 @@ def create_validator_registrations_for_builder(state: BeaconState, validator_ind
     for slot in slots:
       registrations.append(ValidatorRegistrationV2(
         fee_recipient=fee_recipient,
-        builder_index=builder_index,
         gas_limit=gas_limit,
+        builder_index=builder_index,
         validator_index=validator_index
         builder_preferences=builder_preferences,
         proposal_slot=slot
@@ -135,11 +175,14 @@ def validate_bid(
 To obtain an execution payload, a block proposer building a block on top of a
 beacon `state` in a given `slot` must take the following actions:
 
-1. Call upstream builder software to get an `ExecutionPayloadBid`.
+1. Call upstream builder software to get an `ExecutionPayloadBid`. The validator
+   is required to send the `SignedBidRequestAuth` in the request body in order to
+   authenticate the request to the builder. If a builder has multiple builder indices associated with 
+   them, the validator will have to call the upstream builder software each time for each builder index. 
 2. Assemble a `SignedBeaconBlock` according to the process outlined in the
    \[Gloas
    specs\][https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal]
-   but with the `ExecutionPayloadBid` from the prior step.
+   but with the best `ExecutionPayloadBid` from the prior step.
 3. The proposer returns the `SignedBeaconBlock` back to the upstream block
    building software.
 4. The upstream block building software constructs the

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -38,8 +38,9 @@ corresponding to the bid to the PTC committee.
 
 ## Constants
 
-| Name | Value | | -------------------------------- | -------------------| |
-`MAX_SALT_BYTES` | `4096` |
+| Name                                      | Value              |
+| ----------------------------------------- | ------------------ |
+| `MAX_SALT_BYTES`                          | `4096`             |
 
 ## Containers
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -1,18 +1,18 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-**Table of Contents** *generated with
-[DocToc](https://github.com/thlorenz/doctoc)*
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Gloas - Honest Validator](#gloas---honest-validator)
   - [Introduction](#introduction)
+  - [Helper](#helper)
+    - [`get_proposer_slots_in_upcoming_epoch`](#get_proposer_slots_in_upcoming_epoch)
   - [Validator Registrations](#validator-registrations)
     - [Constructing the `ValidatorRegistrationV2`](#constructing-the-validatorregistrationv2)
     - [Validator Registration dissemination](#validator-registration-dissemination)
+  - [Validating a `SignedExecutionPayloadBid`](#validating-a-signedexecutionpayloadbid)
   - [Block proposal](#block-proposal)
-    - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
-      - [ExecutionPayloadBid](#executionpayloadbid)
+      - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
+        - [ExecutionPayloadBid](#executionpayloadbid)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -97,11 +97,36 @@ def create_validator_registrations(state: BeaconState, validator_index: Validato
   return registrations
 ```
 
+## Validating a `SignedExecutionPayloadBid`
+
+When the proposer receives a `SignedExecutionPayloadBid` from a builder, it can
+validate the bid using `validate_bid`. It can discard the bid if the conditions
+are not satisfied.
+
+```python
+def validate_bid(
+    state: BeaconState, signed_bid: SignedExecutionPayloadBid, fee_recipient: ExecutionAddress
+) -> bool:
+    builder = state.builders[signed_bid.builder_index]
+
+    assert signed_bid.slot == state.slot
+    assert signed_bid.fee_recipient == fee_recipient
+    assert signed_bid.parent_block_hash == state.latest_block_hash
+    assert signed_bid.parent_block_root == hash_tree_root(state.latest_block_header)
+    assert signed_bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
+    assert is_builder(state, builder.pubkey)
+
+    if signed_bid.value > 0:
+        assert can_builder_cover_bid(state, signed_bid.builder_index, signed_bid.value)
+
+    return verify_execution_payload_bid_signature(state, signed_bid)
+```
+
 ## Block proposal
 
-#### Constructing the `BeaconBlockBody`
+### Constructing the `BeaconBlockBody`
 
-##### ExecutionPayloadBid
+#### Recieving ExecutionPayloadBid
 
 To obtain an execution payload, a block proposer building a block on top of a
 beacon `state` in a given `slot` must take the following actions:

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -20,7 +20,41 @@ This document explains how a beacon-chain validator can participate in the exter
 Validators request an `ExecutionPayloadBid` from the external builder network to put it in their `SignedBeaconBlock`. 
 The external builder network broadcasts the `SignedExecutionPayloadEnvelope` corresponding to the bid to the PTC commitee. 
 
-### Block proposal
+## Validator Registrations 
+
+### Constructing the `ValidatorRegistrationV2`
+
+To do this, the validator client assembles a [`ValidatorRegistrationV2`][validator-registration-v2] with the following
+information:
+
+* `fee_recipient`: an execution layer address where fees for the validator should go.
+* `builder_pubkey`: the pubkey of the builder to which this registration is being sent to.
+* `gas_limit`: the value a validator prefers for the execution block gas limit.
+* `timestamp`: a recent timestamp later than any previously constructed `ValidatorRegistrationV1`.
+  Builders use this timestamp as a form of anti-DoS and to sequence registrations.
+* `pubkey`: the validator's public key. Used to identify the beacon chain validator and verify the wrapping signature.
+* `can_accept_trusted_payment`: whether the proposer is willing to accept a trusted payment from the builder with pubkey 
+  `builder_pubkey`.
+* `proposal_epoch`: This is set to `get_current_epoch(state) + 1`.
+
+
+### Validator Registration dissemination
+
+This specification suggests validators re-submit registrations only if they will be proposing in the upcoming epoch(E+1). 
+This is to avoid sending a lot of `ValidatorRegistrations` every epoch. This can potentially help reduce the load 
+Validators are expected to perform this check at every epoch boundary. Validators can send their registrations even though
+they won't be proposing in the upcoming epoch.
+
+```python
+def is_next_epoch_proposer(state: BeaconState, validator_index: ValidatorIndex) -> bool:
+    """
+    Check if ``validator_index`` is scheduled to propose in the next epoch.
+    """
+    next_epoch_proposers = state.proposer_lookahead[SLOTS_PER_EPOCH:]
+    return validator_index in next_epoch_proposers
+```
+
+## Block proposal
 
 #### Constructing the `BeaconBlockBody`
 

--- a/types/gloas/bid_request_auth.yaml
+++ b/types/gloas/bid_request_auth.yaml
@@ -1,12 +1,12 @@
 Gloas:
   BidRequestAuth:
     type: object
-    required: [builder_indices]
+    required: [salt]
     properties:
-      builder_indices:
-        type: array
-        items:
-          $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
+      salt:
+        type: string
+        maxLength: 4096
+        description: "A builder-specific salt (max 4096 bytes) used to authenticate bid requests. Must be set to the URL provided by the whitelisted builder."
   SignedBidRequestAuth:
     type: object
     required: [message, signature]

--- a/types/gloas/bid_request_auth.yaml
+++ b/types/gloas/bid_request_auth.yaml
@@ -1,0 +1,22 @@
+Gloas:
+  BidRequestAuth:
+    type: object
+    required: [builder_index, validator_index, proposal_slot]
+    properties:
+      builder_index:
+        $ref: "../../builder-oapi.yaml#/components/schemas/Uint64"
+        description: "The index of the builder to which the validator is sending the request."
+      validator_index:
+        $ref: "../../beacon-apis/types/primitive.yaml#/ValidatorIndex"
+        description: "The index of the validator that is sending the request."
+      proposal_slot:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Slot"
+        description: "The slot at which the proposer is building a block."
+  SignedBidRequestAuth:
+    type: object
+    required: [message, signature]
+    properties:
+      message:
+        $ref: "#/Gloas/BidRequestAuth"
+      signature:
+        $ref: "../../beacon-apis/types/primitive.yaml#/BLSSignature"

--- a/types/gloas/bid_request_auth.yaml
+++ b/types/gloas/bid_request_auth.yaml
@@ -7,10 +7,10 @@ Gloas:
         $ref: "../../builder-oapi.yaml#/components/schemas/Uint64"
         description: "The index of the builder to which the validator is sending the request."
       validator_index:
-        $ref: "../../beacon-apis/types/primitive.yaml#/ValidatorIndex"
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
         description: "The index of the validator that is sending the request."
       proposal_slot:
-        $ref: "../../beacon-apis/types/primitive.yaml#/Slot"
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
         description: "The slot at which the proposer is building a block."
   SignedBidRequestAuth:
     type: object
@@ -19,4 +19,4 @@ Gloas:
       message:
         $ref: "#/Gloas/BidRequestAuth"
       signature:
-        $ref: "../../beacon-apis/types/primitive.yaml#/BLSSignature"
+        $ref: "../../beacon-apis/types/primitive.yaml#/Signature"

--- a/types/gloas/bid_request_auth.yaml
+++ b/types/gloas/bid_request_auth.yaml
@@ -1,17 +1,12 @@
 Gloas:
   BidRequestAuth:
     type: object
-    required: [builder_index, validator_index, proposal_slot]
+    required: [builder_indices]
     properties:
-      builder_index:
-        $ref: "../../builder-oapi.yaml#/components/schemas/Uint64"
-        description: "The index of the builder to which the validator is sending the request."
-      validator_index:
-        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
-        description: "The index of the validator that is sending the request."
-      proposal_slot:
-        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
-        description: "The slot at which the proposer is building a block."
+      builder_indices:
+        type: array
+        items:
+          $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
   SignedBidRequestAuth:
     type: object
     required: [message, signature]

--- a/types/gloas/blinded_envelope.yaml
+++ b/types/gloas/blinded_envelope.yaml
@@ -1,0 +1,37 @@
+Gloas:
+  BlindedExecutionPayloadEnvelope:
+    type: object
+    description: "The `BlindedExecutionPayloadEnvelope` contains roots of execution payload components rather than full data. Used by validators to commit to an envelope without access to full payload."
+    required: [payload_root, execution_requests_root, builder_index, beacon_block_root, slot, blob_kzg_commitments_root, state_root]
+    properties:
+      payload_root:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Root"
+        description: "Root of the execution payload."
+      execution_requests_root:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Root"
+        description: "Root of the execution requests."
+      builder_index:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
+        description: "Index of the builder. For unstaked builders, this MUST be BUILDER_INDEX_SELF_BUILD."
+      beacon_block_root:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Root"
+        description: "Root of the beacon block this envelope corresponds to."
+      slot:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
+        description: "Slot of the block."
+      blob_kzg_commitments_root:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Root"
+        description: "Root of the blob KZG commitments."
+      state_root:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Root"
+        description: "Post-state root after applying the execution payload."
+  SignedBlindedExecutionPayloadEnvelope:
+    type: object
+    description: "The `SignedBlindedExecutionPayloadEnvelope` object containing a blinded envelope and proposer signature."
+    required: [message, signature]
+    properties:
+      message:
+        $ref: "#/Gloas/BlindedExecutionPayloadEnvelope"
+      signature:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Signature"
+

--- a/types/gloas/blinded_envelope.yaml
+++ b/types/gloas/blinded_envelope.yaml
@@ -2,14 +2,14 @@ Gloas:
   BlindedExecutionPayloadEnvelope:
     type: object
     description: "The `BlindedExecutionPayloadEnvelope` contains roots of execution payload components rather than full data. Used by validators to commit to an envelope without access to full payload."
-    required: [payload_root, execution_requests_root, builder_index, beacon_block_root, slot, blob_kzg_commitments_root, state_root]
+    required: [payload_root, execution_requests, builder_index, beacon_block_root, slot, blob_kzg_commitments_root, state_root]
     properties:
       payload_root:
         $ref: "../../beacon-apis/types/primitive.yaml#/Root"
         description: "Root of the execution payload."
-      execution_requests_root:
-        $ref: "../../beacon-apis/types/primitive.yaml#/Root"
-        description: "Root of the execution requests."
+      execution_requests:
+        $ref: "../../beacon-apis/types/electra/requests.yaml#/Electra/ExecutionRequests"
+        description: "Execution layer requests (deposits, withdrawals, consolidations)."
       builder_index:
         $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
         description: "Index of the builder. For unstaked builders, this MUST be BUILDER_INDEX_SELF_BUILD."

--- a/types/gloas/builder_bid.yaml
+++ b/types/gloas/builder_bid.yaml
@@ -1,0 +1,30 @@
+Gloas:
+  BuilderBid:
+    type: object
+    description: "The `BuilderBid` object for Gloas fork from unstaked builders. Contains execution payload header, blob commitments, execution requests, and a SignedExecutionPayloadBid."
+    required: [header, blob_kzg_commitments, execution_requests, bid]
+    properties:
+      header:
+        $ref: "../../beacon-apis/types/deneb/execution_payload.yaml#/Deneb/ExecutionPayloadHeader"
+        description: "The execution payload header for the proposed block."
+      blob_kzg_commitments:
+        type: array
+        items:
+          $ref: "../../beacon-apis/types/primitive.yaml#/KZGCommitment"
+        description: "KZG commitments for any blobs attached to the execution payload."
+      execution_requests:
+        $ref: "../../beacon-apis/types/electra/requests.yaml#/Electra/ExecutionRequests"
+        description: "Execution layer requests (deposits, withdrawals, consolidations)."
+      bid:
+        $ref: "../../beacon-apis/types/gloas/execution_payload_bid.yaml#/Gloas/SignedExecutionPayloadBid"
+        description: "The signed execution payload bid. builder_index MUST be set to BUILDER_INDEX_SELF_BUILD."
+  SignedBuilderBid:
+    type: object
+    description: "The `SignedBuilderBid` object for Gloas fork."
+    required: [message, signature]
+    properties:
+      message:
+        $ref: "#/Gloas/BuilderBid"
+      signature:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Signature"
+

--- a/types/gloas/registration.yaml
+++ b/types/gloas/registration.yaml
@@ -2,11 +2,11 @@ Gloas:
   BuilderPreferences:
     type: object
     description: "Per-builder preferences that a validator can express."
-    required: [execution_payment_accepted]
+    required: [max_trusted_bid]
     properties:
-      execution_payment_accepted:
-        type: boolean
-        description: "Indicates that the proposer is willing to accept a trusted execution layer payment from the builder."
+      max_trusted_bid:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
+        description: "Indicates the maximum amount that a proposer is willing to accept as a trusted payment amount from the builder."
   ValidatorRegistrationV2:
     type: object
     description: "The `ValidatorRegistrationV2` object for Gloas fork, replacing pubkey and timestamp with validator_index, proposal_slot, and builder_preferences."

--- a/types/gloas/registration.yaml
+++ b/types/gloas/registration.yaml
@@ -1,0 +1,38 @@
+Gloas:
+  BuilderPreferences:
+    type: object
+    description: "Per-builder preferences that a validator can express."
+    required: [execution_payment_accepted]
+    properties:
+      execution_payment_accepted:
+        type: boolean
+        description: "Indicates that the proposer is willing to accept a trusted execution layer payment from the builder."
+  ValidatorRegistrationV2:
+    type: object
+    description: "The `ValidatorRegistrationV2` object for Gloas fork, replacing pubkey and timestamp with validator_index, proposal_slot, and builder_preferences."
+    required: [validator_index, fee_recipient, proposal_slot, gas_limit, builder_preferences]
+    properties:
+      validator_index:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
+        description: "Validator index. Used to identify the beacon chain validator and verify the signature."
+      fee_recipient:
+        $ref: "../../beacon-apis/types/primitive.yaml#/ExecutionAddress"
+        description: "Address to receive fees from the block."
+      proposal_slot:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
+        description: "The slot at which this validator is proposing."
+      gas_limit:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
+        description: "Preferred gas limit of validator."
+      builder_preferences:
+        $ref: "#/Gloas/BuilderPreferences"
+        description: "Per-builder preferences."
+  SignedValidatorRegistrationV2:
+    type: object
+    description: "The `SignedValidatorRegistrationV2` object for Gloas fork."
+    required: [message, signature]
+    properties:
+      message:
+        $ref: "#/Gloas/ValidatorRegistrationV2"
+      signature:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Signature"

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -28,6 +28,11 @@ validator's
 vc
 wei
 EIP
+ePBS
 Fulu
 fulu
+Gloas
+gloas
+PTC
 submitBlindedBlockV
+ValidatorRegistrationsV

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -33,6 +33,7 @@ Fulu
 fulu
 Gloas
 gloas
+Gwei
 PTC
 submitBlindedBlockV
 ValidatorRegistrationsV


### PR DESCRIPTION
This PR extends the Builder-API for ePBS to support unstaked builders - builders who do not have staked collateral on the beacon chain.

## Background
While the staked builder flow (introduced in the parent PR) allows builders with on-chain collateral to provide SignedExecutionPayloadBid directly to proposers, unstaked builders operate differently. They function similarly to current MEV-Boost relays, providing full block contents while utilizing the new ePBS primitives.
The key distinction is that unstaked builders use BUILDER_INDEX_SELF_BUILD (2**64 - 1) as their builder index, indicating that the proposer is effectively "self-building" with the unstaked builder's block contents.

## New APIs
We introduce 2 new APIs for unstaked builder interactions:
1. **getBuilderBid**: GET /eth/v1/builder/header/{slot}/{parent_hash}/{parent_root}/{pubkey}
This API is called by the proposer to an unstaked builder/relay. The builder returns a SignedBuilderBid containing: ExecutionPayloadHeader for the proposed block blob_kzg_commitments for any associated blobs, execution_requests and SignedExecutionPayloadBid with builder_index set to `BUILDER_INDEX_SELF_BUILD`.
2. **submitBlockAndEnvelope**: POST /eth/v1/builder/block_and_envelope
This API is called by the proposer to submit both the SignedBeaconBlock and a SignedBlindedExecutionPayloadEnvelope to the unstaked builder. Upon receiving this, the builder validates the block and envelope signatures, unblinds the BlindedExecutionPayloadEnvelope with the full execution payload, broadcasts the SignedExecutionPayloadEnvelope to the PTC committee

## Flow Overview
1. Proposer calls getBuilderBid → Unstaked Builder
2. Unstaked Builder returns SignedBuilderBid (header, commitments, requests, bid)
3. Proposer constructs SignedBeaconBlock with the bid
4. Proposer constructs SignedBlindedExecutionPayloadEnvelope
5. Proposer calls submitBlockAndEnvelope with both objects → Unstaked Builder
6. Unstaked Builder unblinds the envelope and broadcasts SignedExecutionPayloadEnvelope to PTC committee

## Relationship to Staked Builder API
This specification complements the staked builder API. Proposers can interact with both staked and unstaked builders simultaneously, choosing the best bid from either source. The builder_index field distinguishes between them:
Staked builders: Use their actual on-chain builder index
Unstaked builders: Use BUILDER_INDEX_SELF_BUILD

**Disclaimer**: This specification was generated using the help of AI. This specification has been drafted to understand how the Builder-API for unstaked builders could potentially look like. The author strongly discourages unstaked builders to encourage with the protocol as the staking amount for builders has gone down to 1Eth.