### PR TITLE
Fix table formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "blacken-docs>=1.16.0",
     "codespell>=2.4.1",
     "mdformat>=1.0.0",
+    "mdformat-gfm>=1.0.0",
 ]
 
 [tool.codespell]

--- a/specs/bellatrix/builder.md
+++ b/specs/bellatrix/builder.md
@@ -42,13 +42,15 @@
 
 ### Domain types
 
-| Name | Value | | - | - | | `DOMAIN_APPLICATION_BUILDER` |
-`DomainType('0x00000001')` |
+| Name                         | Value                      |
+| ---------------------------- | -------------------------- |
+| `DOMAIN_APPLICATION_BUILDER` | `DomainType('0x00000001')` |
 
 ### Time parameters
 
-| Name | Value | Unit | Duration | | - | - | - | - | |
-`MAX_REGISTRATION_LOOKAHEAD` | `uint64(10)` | seconds | 10 seconds |
+| Name                         | Value        | Unit    | Duration   |
+| ---------------------------- | ------------ | ------- | ---------- |
+| `MAX_REGISTRATION_LOOKAHEAD` | `uint64(10)` | seconds | 10 seconds |
 
 ## Containers
 

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -50,9 +50,10 @@ material in the [Builder spec][builder-spec] and by extension the
 
 ## Constants
 
-| Name | Value | Units | | - | - | - | |
-`EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION` | 1 | epoch(s)| |
-`BUILDER_PROPOSAL_DELAY_TOLERANCE` | 1 | second(s) |
+| Name                                           | Value | Units     |
+| ---------------------------------------------- | ----- | --------- |
+| `EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION` | 1     | epoch(s)  |
+| `BUILDER_PROPOSAL_DELAY_TOLERANCE`             | 1     | second(s) |
 
 ## Validator registration
 

--- a/uv.lock
+++ b/uv.lock
@@ -49,6 +49,7 @@ dependencies = [
     { name = "blacken-docs" },
     { name = "codespell" },
     { name = "mdformat" },
+    { name = "mdformat-gfm" },
 ]
 
 [package.metadata]
@@ -56,6 +57,7 @@ requires-dist = [
     { name = "blacken-docs", specifier = ">=1.16.0" },
     { name = "codespell", specifier = ">=2.4.1" },
     { name = "mdformat", specifier = ">=1.0.0" },
+    { name = "mdformat-gfm", specifier = ">=1.0.0" },
 ]
 
 [[package]]
@@ -113,6 +115,33 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat-gfm"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -164,4 +193,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/a762be14dae1c3bf280202ba3172020b2b0b4c537f94427435f19c413b72/pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a", size = 17644, upload-time = "2025-11-05T13:36:35.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/25/d9db8be44e205a124f6c98bc0324b2bb149b7431c53877fc6d1038dddaf5/pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3", size = 12195, upload-time = "2025-11-05T13:36:33.183Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]


### PR DESCRIPTION
mdformat --wrap=80 was collapsing markdown tables onto  single lines because it treated table rows as regular text. Adding    mdformat-gfm  gives mdformat GFM table awareness so tables are properly formatted and preserved across lint runs.