### PR TITLE
Fix US spelling for proposer preferences deprecation notes

### DIFF
--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -135,7 +135,7 @@ for.
 
 ## Proposer Preferences (Deprecation of Validator Registrations)
 
-*Note*: `ValidatorRegistrationV1` is **deprecated** in favour of
+*Note*: `ValidatorRegistrationV1` is **deprecated** in favor of
 [`ProposerPreferences`][proposer-preferences] from the consensus specs.
 
 Builders SHOULD subscribe to the

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -79,7 +79,7 @@ authentication purposes.
 ## Proposer Preferences
 
 *Note*: Validator registrations (`ValidatorRegistrationV1`) are **deprecated**
-in favour of [`ProposerPreferences`][proposer-preferences] from the consensus
+in favor of [`ProposerPreferences`][proposer-preferences] from the consensus
 specs.
 
 General validator preferences are now communicated via the


### PR DESCRIPTION
## Summary
This PR applies a small wording fix to satisfy the spellcheck workflow.

## Changes
- Replaced `favour` with `favor` in:
  - `specs/gloas/validator.md`
  - `specs/gloas/builder.md`

## Impact
- No behavioral or API changes
- No schema/type changes
- Documentation-only update
