### PR TITLE
Fix gloas docs spelling for spellcheck

### DIFF
--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -135,7 +135,7 @@ for.
 
 ## Proposer Preferences (Deprecation of Validator Registrations)
 
-*Note*: `ValidatorRegistrationV1` is **deprecated** in favour of
+*Note*: `ValidatorRegistrationV1` is **deprecated** in favor of
 [`ProposerPreferences`][proposer-preferences] from the consensus specs.
 
 Builders SHOULD subscribe to the

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -79,7 +79,7 @@ authentication purposes.
 ## Proposer Preferences
 
 *Note*: Validator registrations (`ValidatorRegistrationV1`) are **deprecated**
-in favour of [`ProposerPreferences`][proposer-preferences] from the consensus
+in favor of [`ProposerPreferences`][proposer-preferences] from the consensus
 specs.
 
 General validator preferences are now communicated via the


### PR DESCRIPTION
## Summary

This PR fixes spelling issues flagged by the spellcheck GitHub Action in Gloas docs.

Changes made:
- Replaced `in favour of` with `in favor of` in:
  - `specs/gloas/builder.md`
  - `specs/gloas/validator.md`

## Why

CI failed in `rojopolis/spellcheck-github-actions` due to `favour` being reported as misspelled by the configured dictionary.

## Scope

Documentation-only change. No API, schema, or behavior changes.
