### PR TITLE
Endpoint to submit builder preferences 

### DIFF
--- a/apis/builder/beacon_block.yaml
+++ b/apis/builder/beacon_block.yaml
@@ -8,6 +8,8 @@ post:
     valid. If the signed beacon block was invalid, then the builder
     must return an error response (400) with a description of the validation
     failure.
+
+    This API is applicable from Gloas fork onwards.
   tags:
     - Builder
   parameters:

--- a/apis/builder/beacon_block.yaml
+++ b/apis/builder/beacon_block.yaml
@@ -4,7 +4,7 @@ post:
   description: |
     Submits a `SignedBeaconBlock` to the builder, binding the proposer to the block. 
 
-    A success response (200) indicates that the signed beacon block was
+    A success response (202) indicates that the signed beacon block was
     valid. If the signed beacon block was invalid, then the builder
     must return an error response (400) with a description of the validation
     failure.

--- a/apis/builder/builder_preferences.yaml
+++ b/apis/builder/builder_preferences.yaml
@@ -2,11 +2,14 @@ post:
   operationId: "submitBuilderPreferences"
   summary: Submit builder preferences for a proposer.
   description: |
-    Submits a proposer's `BuilderPreferences` to the builder, including the
+    Submits a proposer's `SignedBuilderPreferences` to the builder, including the
     `max_trusted_bid` that the proposer is willing to accept from this builder.
 
-    The `builder_pubkey` in the body MUST match the builder's own identity.
+    The `builder_pubkey` in the message MUST match the builder's own identity.
     If it does not, the builder MUST return a 400 response.
+
+    The builder MUST verify the BLS signature against `message.proposer_pubkey`.
+    If signature verification fails, the builder MUST return a 400 response.
 
     A success response (200) indicates that the preferences were accepted. If
     the preferences are invalid, then the builder MUST return an error response
@@ -16,12 +19,12 @@ post:
   tags:
     - Builder
   requestBody:
-    description: A `BuilderPreferences` object expressing the proposer's per-builder preferences.
+    description: A `SignedBuilderPreferences` object expressing the proposer's per-builder preferences.
     required: true
     content:
       application/json:
         schema:
-          $ref: "../../types/gloas/builder_preferences.yaml#/Gloas/BuilderPreferences"
+          $ref: "../../types/gloas/builder_preferences.yaml#/Gloas/SignedBuilderPreferences"
   responses:
     "200":
       description: Success response.

--- a/apis/builder/builder_preferences.yaml
+++ b/apis/builder/builder_preferences.yaml
@@ -1,0 +1,44 @@
+post:
+  operationId: "submitBuilderPreferences"
+  summary: Submit builder preferences for a proposer.
+  description: |
+    Submits a proposer's `BuilderPreferences` to the builder, including the
+    `max_trusted_bid` that the proposer is willing to accept from this builder.
+
+    The `builder_pubkey` in the body MUST match the builder's own identity.
+    If it does not, the builder MUST return a 400 response.
+
+    A success response (200) indicates that the preferences were accepted. If
+    the preferences are invalid, then the builder MUST return an error response
+    (400) with a description of the validation failure.
+
+    This API is applicable from Gloas fork onwards.
+  tags:
+    - Builder
+  requestBody:
+    description: A `BuilderPreferences` object expressing the proposer's per-builder preferences.
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../../types/gloas/builder_preferences.yaml#/Gloas/BuilderPreferences"
+  responses:
+    "200":
+      description: Success response.
+    "400":
+      description: Error response.
+      content:
+        application/json:
+          schema:
+            $ref: "../../builder-oapi.yaml#/components/schemas/ErrorMessage"
+          examples:
+            WrongBuilder:
+              value:
+                code: 400
+                message: "builder_pubkey does not match this builder's identity"
+            InvalidPreferences:
+              value:
+                code: 400
+                message: "Invalid builder preferences: max_trusted_bid malformed"
+    "500":
+      $ref: "../../builder-oapi.yaml#/components/responses/InternalError"

--- a/apis/builder/builder_preferences.yaml
+++ b/apis/builder/builder_preferences.yaml
@@ -5,9 +5,9 @@ post:
     Submits a proposer's `SignedBuilderPreferences` to the builder, including the
     `max_trusted_bid` that the proposer is willing to accept from this builder.
 
-    Validators SHOULD call this endpoint an epoch prior to their proposing epoch
-    based on the proposer lookahead, so that builders have the preferences before
-    the bid request arrives.
+    Validators SHOULD call this endpoint in the epoch prior to the epoch in
+    which they will be proposing, as determined from `state.lookahead`, so that
+    builders have the preferences before the bid request arrives.
 
     The `builder_pubkey` in the message MUST match the builder's own identity.
     If it does not, the builder MUST return a 400 response.

--- a/apis/builder/builder_preferences.yaml
+++ b/apis/builder/builder_preferences.yaml
@@ -11,17 +11,24 @@ post:
     builders have the preferences before the bid request arrives.
 
     The builder MUST verify the BLS signature in `auth` against
-    `preferences.validator_pubkey`, and check that `auth.message.builder_pubkey`
+    `validator_pubkey`, and check that `auth.message.builder_pubkey`
     matches its own identity. If either check fails, the builder MUST return a
     400 response.
 
-    A success response (200) indicates that the preferences were accepted. If
+    A success response (202) indicates that the preferences were accepted. If
     the preferences are invalid, then the builder MUST return an error response
     (400) with a description of the validation failure.
 
     This API is applicable from Gloas fork onwards.
   tags:
     - Builder
+  parameters:
+    - name: validator_pubkey
+      in: path
+      required: true
+      description: "The BLS public key of the validator expressing these preferences."
+      schema:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
   requestBody:
     description: A `BuilderPreferencesRequest` containing the proposer's preferences and a `SignedRequestAuth` for authentication.
     required: true

--- a/apis/builder/builder_preferences.yaml
+++ b/apis/builder/builder_preferences.yaml
@@ -2,18 +2,21 @@ post:
   operationId: "submitBuilderPreferences"
   summary: Submit builder preferences for a proposer.
   description: |
-    Submits a proposer's `SignedBuilderPreferences` to the builder, including the
-    `max_trusted_bid` that the proposer is willing to accept from this builder.
+    Submits a proposer's `BuilderPreferencesRequest` to the builder, including
+    the `max_trusted_bid` that the proposer is willing to accept from this
+    builder, authenticated via a `SignedRequestAuth`.
 
-    Validators SHOULD call this endpoint in the epoch prior to the epoch in
+    Validators MAY call this endpoint in the epoch prior to the epoch in
     which they will be proposing, as determined from `state.lookahead`, so that
     builders have the preferences before the bid request arrives.
 
-    The `builder_pubkey` in the message MUST match the builder's own identity.
+    The `preferences.builder_pubkey` MUST match the builder's own identity.
     If it does not, the builder MUST return a 400 response.
 
-    The builder MUST verify the BLS signature against `message.proposer_pubkey`.
-    If signature verification fails, the builder MUST return a 400 response.
+    The builder MUST verify the BLS signature in `auth` against the validator
+    pubkey resolved from `preferences.validator_pubkey`, and check that
+    `auth.message.builder_pubkey` matches its own identity. If verification
+    fails, the builder MUST return a 400 response.
 
     A success response (200) indicates that the preferences were accepted. If
     the preferences are invalid, then the builder MUST return an error response
@@ -23,12 +26,12 @@ post:
   tags:
     - Builder
   requestBody:
-    description: A `SignedBuilderPreferences` object expressing the proposer's per-builder preferences.
+    description: A `BuilderPreferencesRequest` containing the proposer's preferences and a `SignedRequestAuth` for authentication.
     required: true
     content:
       application/json:
         schema:
-          $ref: "../../types/gloas/builder_preferences.yaml#/Gloas/SignedBuilderPreferences"
+          $ref: "../../types/gloas/builder_preferences.yaml#/Gloas/BuilderPreferencesRequest"
   responses:
     "200":
       description: Success response.

--- a/apis/builder/builder_preferences.yaml
+++ b/apis/builder/builder_preferences.yaml
@@ -5,6 +5,10 @@ post:
     Submits a proposer's `SignedBuilderPreferences` to the builder, including the
     `max_trusted_bid` that the proposer is willing to accept from this builder.
 
+    Validators SHOULD call this endpoint an epoch prior to their proposing epoch
+    based on the proposer lookahead, so that builders have the preferences before
+    the bid request arrives.
+
     The `builder_pubkey` in the message MUST match the builder's own identity.
     If it does not, the builder MUST return a 400 response.
 

--- a/apis/builder/builder_preferences.yaml
+++ b/apis/builder/builder_preferences.yaml
@@ -10,13 +10,10 @@ post:
     which they will be proposing, as determined from `state.lookahead`, so that
     builders have the preferences before the bid request arrives.
 
-    The `preferences.builder_pubkey` MUST match the builder's own identity.
-    If it does not, the builder MUST return a 400 response.
-
-    The builder MUST verify the BLS signature in `auth` against the validator
-    pubkey resolved from `preferences.validator_pubkey`, and check that
-    `auth.message.builder_pubkey` matches its own identity. If verification
-    fails, the builder MUST return a 400 response.
+    The builder MUST verify the BLS signature in `auth` against
+    `preferences.validator_pubkey`, and check that `auth.message.builder_pubkey`
+    matches its own identity. If either check fails, the builder MUST return a
+    400 response.
 
     A success response (200) indicates that the preferences were accepted. If
     the preferences are invalid, then the builder MUST return an error response
@@ -45,7 +42,7 @@ post:
             WrongBuilder:
               value:
                 code: 400
-                message: "builder_pubkey does not match this builder's identity"
+                message: "auth.message.builder_pubkey does not match this builder's identity"
             InvalidPreferences:
               value:
                 code: 400

--- a/apis/builder/builder_preferences.yaml
+++ b/apis/builder/builder_preferences.yaml
@@ -36,6 +36,9 @@ post:
       application/json:
         schema:
           $ref: "../../types/gloas/builder_preferences.yaml#/Gloas/BuilderPreferencesRequest"
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized `BuilderPreferencesRequest` bytes. Use content type header to indicate that SSZ data is contained in the request body."
   responses:
     "200":
       description: Success response.

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -19,8 +19,9 @@ post:
 
     The `X-Eth-Max-Trusted-Bid` header is optional. A validator MAY send it
     if they have not already submitted a `SignedBuilderPreferences` to this
-    builder. If both are present, the header takes precedence for this request.
-    If neither is present, the builder MUST treat `max_trusted_bid` as `0`.
+    builder. If both are present, the stored `BuilderPreferences` takes
+    precedence over the header. If neither is present, the builder MUST treat
+    `max_trusted_bid` as `0`.
 
     The `SignedRequestAuth` body is optional. If it is present but malformed
     or fails signature verification, the builder MAY return a 400 response.
@@ -102,8 +103,9 @@ post:
         Optional decimal `uint64` (in Gwei) carrying the proposer's
         `max_trusted_bid` for this request. MAY be sent if the validator has
         not already submitted a `SignedBuilderPreferences` to this builder.
-        If present, `bid.execution_payment` MUST NOT exceed this value and it
-        takes precedence over any previously submitted `BuilderPreferences`.
+        If a stored `BuilderPreferences` exists for this proposer, it takes
+        precedence over this header. If no `BuilderPreferences` has been
+        submitted, `bid.execution_payment` MUST NOT exceed this value.
         A value of `0` indicates that the proposer does not accept any trusted
         payments from this builder. A value of `2**64 - 1` (`MAX_TRUSTED_BID`)
         indicates that the proposer accepts any trusted payment amount.

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -10,16 +10,15 @@ post:
     - The hash of the execution layer block the proposer will build on.
     - The root of the beacon block the proposer will build on.
     - The index of the proposer.
-    - The `X-Eth-Max-Trusted-Bid` header carrying the proposer's
-      `max_trusted_bid` (decimal `uint64`, in Gwei) for this request.
     - Optionally, a `SignedRequestAuth` in the request body that
       authenticates the request. The body MAY be encoded as JSON
       (`Content-Type: application/json`) or SSZ
       (`Content-Type: application/octet-stream`).
 
-    The `X-Eth-Max-Trusted-Bid` header is required. If it is missing or
-    malformed, the builder MUST NOT serve a bid for the proposer and MUST
-    return a 400 response.
+    The builder uses the `max_trusted_bid` previously submitted via the
+    `/eth/v1/builder/builder_preferences/{proposer_index}` endpoint to
+    enforce payment limits. If no preferences have been submitted, the
+    builder MUST treat the `max_trusted_bid` as `0`.
 
     The `SignedRequestAuth` body is optional. If it is present but malformed
     or fails signature verification, the builder MAY return a 400 response.
@@ -94,21 +93,6 @@ post:
         request body belongs. Required if the request body is SSZ encoded.
       schema:
         $ref: "../../builder-oapi.yaml#/components/schemas/ConsensusVersion"
-    - name: X-Eth-Max-Trusted-Bid
-      in: header
-      required: true
-      description: |
-        Decimal `uint64` (in Gwei) carrying the proposer's `max_trusted_bid`
-        for this request. `bid.execution_payment` MUST NOT exceed this value.
-        A value of `0` indicates that the proposer does not accept any
-        trusted payments from this builder. A value of `2**64 - 1`
-        (`MAX_TRUSTED_BID`) indicates that the proposer accepts any trusted
-        payment amount. If the header is missing or malformed, the builder
-        MUST return a 400 response.
-      schema:
-        type: integer
-        format: uint64
-        example: 1000000000
   requestBody:
     description: |
       Optional `SignedRequestAuth` authenticating the request. If provided,
@@ -165,10 +149,6 @@ post:
               value:
                 code: 400
                 message: "Invalid SignedRequestAuth: signature verification failed"
-            MissingMaxTrustedBid:
-              value:
-                code: 400
-                message: "Missing X-Eth-Max-Trusted-Bid header"
     "401":
       description: Authentication required.
       content:

--- a/apis/builder/execution_payload_bid.yaml
+++ b/apis/builder/execution_payload_bid.yaml
@@ -10,15 +10,17 @@ post:
     - The hash of the execution layer block the proposer will build on.
     - The root of the beacon block the proposer will build on.
     - The index of the proposer.
+    - The `X-Eth-Max-Trusted-Bid` header carrying the proposer's
+      `max_trusted_bid` (decimal `uint64`, in Gwei) for this request.
     - Optionally, a `SignedRequestAuth` in the request body that
       authenticates the request. The body MAY be encoded as JSON
       (`Content-Type: application/json`) or SSZ
       (`Content-Type: application/octet-stream`).
 
-    The builder uses the `max_trusted_bid` previously submitted via the
-    `/eth/v1/builder/builder_preferences/{proposer_index}` endpoint to
-    enforce payment limits. If no preferences have been submitted, the
-    builder MUST treat the `max_trusted_bid` as `0`.
+    The `X-Eth-Max-Trusted-Bid` header is optional. A validator MAY send it
+    if they have not already submitted a `SignedBuilderPreferences` to this
+    builder. If both are present, the header takes precedence for this request.
+    If neither is present, the builder MUST treat `max_trusted_bid` as `0`.
 
     The `SignedRequestAuth` body is optional. If it is present but malformed
     or fails signature verification, the builder MAY return a 400 response.
@@ -93,6 +95,22 @@ post:
         request body belongs. Required if the request body is SSZ encoded.
       schema:
         $ref: "../../builder-oapi.yaml#/components/schemas/ConsensusVersion"
+    - name: X-Eth-Max-Trusted-Bid
+      in: header
+      required: false
+      description: |
+        Optional decimal `uint64` (in Gwei) carrying the proposer's
+        `max_trusted_bid` for this request. MAY be sent if the validator has
+        not already submitted a `SignedBuilderPreferences` to this builder.
+        If present, `bid.execution_payment` MUST NOT exceed this value and it
+        takes precedence over any previously submitted `BuilderPreferences`.
+        A value of `0` indicates that the proposer does not accept any trusted
+        payments from this builder. A value of `2**64 - 1` (`MAX_TRUSTED_BID`)
+        indicates that the proposer accepts any trusted payment amount.
+      schema:
+        type: integer
+        format: uint64
+        example: 1000000000
   requestBody:
     description: |
       Optional `SignedRequestAuth` authenticating the request. If provided,

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -114,8 +114,8 @@ components:
       $ref: "./types/gloas/request_auth.yaml#/Gloas/SignedRequestAuth"
     Gloas.BuilderPreferences:
       $ref: "./types/gloas/builder_preferences.yaml#/Gloas/BuilderPreferences"
-    Gloas.SignedBuilderPreferences:
-      $ref: "./types/gloas/builder_preferences.yaml#/Gloas/SignedBuilderPreferences"
+    Gloas.BuilderPreferencesRequest:
+      $ref: "./types/gloas/builder_preferences.yaml#/Gloas/BuilderPreferencesRequest"
   
   responses:
     InternalError:

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -114,6 +114,8 @@ components:
       $ref: "./types/gloas/request_auth.yaml#/Gloas/SignedRequestAuth"
     Gloas.BuilderPreferences:
       $ref: "./types/gloas/builder_preferences.yaml#/Gloas/BuilderPreferences"
+    Gloas.SignedBuilderPreferences:
+      $ref: "./types/gloas/builder_preferences.yaml#/Gloas/SignedBuilderPreferences"
   
   responses:
     InternalError:

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -61,6 +61,8 @@ paths:
     $ref: "./apis/builder/blinded_blocks.yaml"
   /eth/v2/builder/blinded_blocks:
     $ref: "./apis/builder/blinded_blocks_v2.yaml"
+  /eth/v1/builder/builder_preferences:
+    $ref: "./apis/builder/builder_preferences.yaml"
   /eth/v1/builder/status:
     $ref: "./apis/builder/status.yaml"
 
@@ -110,6 +112,8 @@ components:
       $ref: "./types/gloas/request_auth.yaml#/Gloas/RequestAuth"
     Gloas.SignedRequestAuth:
       $ref: "./types/gloas/request_auth.yaml#/Gloas/SignedRequestAuth"
+    Gloas.BuilderPreferences:
+      $ref: "./types/gloas/builder_preferences.yaml#/Gloas/BuilderPreferences"
   
   responses:
     InternalError:

--- a/builder-oapi.yaml
+++ b/builder-oapi.yaml
@@ -61,7 +61,7 @@ paths:
     $ref: "./apis/builder/blinded_blocks.yaml"
   /eth/v2/builder/blinded_blocks:
     $ref: "./apis/builder/blinded_blocks_v2.yaml"
-  /eth/v1/builder/builder_preferences:
+  /eth/v1/builder/builder_preferences/{validator_pubkey}:
     $ref: "./apis/builder/builder_preferences.yaml"
   /eth/v1/builder/status:
     $ref: "./apis/builder/status.yaml"

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -79,8 +79,10 @@ def is_eligible_for_bid(
 ## Builder Preferences
 
 Validators communicate their per-builder preferences ahead of the bid request by
-calling the [`submitBuilderPreferences`][submit-builder-preferences-api] API.
-The builder receives a `SignedBuilderPreferences` object whose `message` contains:
+calling the [`submitBuilderPreferences`][submit-builder-preferences-api] API,
+typically an epoch prior to their proposing epoch based on the proposer
+lookahead. The builder receives a `SignedBuilderPreferences` object whose
+`message` contains:
 
 - `max_trusted_bid`: The maximum trusted execution layer payment the proposer
   will accept from this builder (in Gwei).
@@ -116,16 +118,18 @@ Validators communicate per-request inputs to a builder on each
 - Optionally, the `X-Eth-Max-Trusted-Bid` header carrying a decimal `uint64`
   (in Gwei) with the proposer's `max_trusted_bid` for this request. MAY be
   omitted if the proposer has already submitted a `SignedBuilderPreferences`
-  to this builder. If present, it takes precedence over stored
-  `BuilderPreferences` for this request.
+  to this builder. If a stored `BuilderPreferences` exists for the proposer,
+  it takes precedence over this header.
 - Optionally, a [`SignedRequestAuth`][signed-request-auth] in the request body
   used to authenticate the requesting validator. The body MAY be encoded as JSON
   (`Content-Type: application/json`) or SSZ
   (`Content-Type: application/octet-stream`); when SSZ is used, the
   `Eth-Consensus-Version` header MUST also be set.
 
-If neither the `X-Eth-Max-Trusted-Bid` header nor a stored `BuilderPreferences`
-is available for the proposer, the builder MUST treat `max_trusted_bid` as `0`.
+The builder resolves `max_trusted_bid` in the following order of precedence:
+1. Stored `BuilderPreferences` for the proposer, if previously submitted.
+2. The `X-Eth-Max-Trusted-Bid` header, if present on this request.
+3. `0`, if neither is available.
 
 If the request body is present, builders MAY verify the `SignedRequestAuth`
 signature against the validator pubkey resolved from the `proposer_index` path

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -79,9 +79,9 @@ def is_eligible_for_bid(
 ## Builder Preferences
 
 Validators communicate their per-builder preferences ahead of the bid request by
-calling the [`submitBuilderPreferences`][submit-builder-preferences-api] API,
-typically an epoch prior to their proposing epoch based on the proposer
-lookahead. The builder receives a `SignedBuilderPreferences` object whose
+calling the [`submitBuilderPreferences`][submit-builder-preferences-api] API in
+the epoch prior to the epoch in which they will be proposing, as determined from
+`state.lookahead`. The builder receives a `SignedBuilderPreferences` object whose
 `message` contains:
 
 - `max_trusted_bid`: The maximum trusted execution layer payment the proposer

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -83,17 +83,17 @@ request by calling the [`submitBuilderPreferences`][submit-builder-preferences-a
 API in the epoch prior to the epoch in which they will be proposing, as
 determined from `state.lookahead`. The builder receives a `BuilderPreferencesRequest` object containing:
 
+- `validator_pubkey`: The BLS public key of the validator submitting these
+  preferences, passed as a path parameter.
 - `preferences`: A `BuilderPreferences` with:
   - `max_trusted_bid`: The maximum trusted execution layer payment the proposer
     will accept from this builder (in Gwei).
-  - `validator_pubkey`: The BLS public key of the validator submitting these
-    preferences.
 - `auth`: A `SignedRequestAuth` authenticating the request. The builder MUST
   check that `auth.message.builder_pubkey` matches its own identity and MUST
-  verify the BLS signature against `preferences.validator_pubkey`. If either
-  check fails, the builder MUST return a 400 response.
+  verify the BLS signature against the `validator_pubkey` path parameter. If
+  either check fails, the builder MUST return a 400 response.
 
-The builder MUST store the preferences for each proposer and apply the
+The builder SHOULD store the preferences for each proposer and apply the
 `max_trusted_bid` constraint when constructing bids. If no preferences have been
 submitted for a proposer, the builder MUST treat the proposer's `max_trusted_bid`
 as `0`.

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -78,22 +78,23 @@ def is_eligible_for_bid(
 
 ## Builder Preferences
 
-Validators communicate their per-builder preferences ahead of the bid request by
-calling the [`submitBuilderPreferences`][submit-builder-preferences-api] API in
-the epoch prior to the epoch in which they will be proposing, as determined from
-`state.lookahead`. The builder receives a `SignedBuilderPreferences` object whose
-`message` contains:
+Validators MAY communicate their per-builder preferences ahead of the bid
+request by calling the [`submitBuilderPreferences`][submit-builder-preferences-api]
+API in the epoch prior to the epoch in which they will be proposing, as
+determined from `state.lookahead`. The builder receives a `BuilderPreferencesRequest` object containing:
 
-- `max_trusted_bid`: The maximum trusted execution layer payment the proposer
-  will accept from this builder (in Gwei).
-- `builder_pubkey`: The BLS public key of this builder. The builder MUST return
-  a 400 response if this does not match its own identity.
-- `proposer_pubkey`: The BLS public key of the proposer submitting these
-  preferences.
+- `preferences`: A `BuilderPreferences` with:
+  - `max_trusted_bid`: The maximum trusted execution layer payment the proposer
+    will accept from this builder (in Gwei).
+  - `builder_pubkey`: The BLS public key of this builder. The builder MUST
+    return a 400 response if this does not match its own identity.
+  - `validator_pubkey`: The BLS public key of the validator submitting these
+    preferences.
+- `auth`: A `SignedRequestAuth` authenticating the request.
 
-The builder MUST verify the BLS signature against `message.proposer_pubkey`
-before storing the preferences. If verification fails, the builder MUST return a
-400 response.
+The builder MUST verify the BLS signature in `auth` against
+`preferences.validator_pubkey` before storing the preferences. If verification
+fails, the builder MUST return a 400 response.
 
 The builder MUST store the preferences for each proposer and apply the
 `max_trusted_bid` constraint when constructing bids. If no preferences have been
@@ -117,7 +118,7 @@ Validators communicate per-request inputs to a builder on each
 
 - Optionally, the `X-Eth-Max-Trusted-Bid` header carrying a decimal `uint64`
   (in Gwei) with the proposer's `max_trusted_bid` for this request. MAY be
-  omitted if the proposer has already submitted a `SignedBuilderPreferences`
+  omitted if the proposer has already submitted a `BuilderPreferencesRequest`
   to this builder. If a stored `BuilderPreferences` exists for the proposer,
   it takes precedence over this header.
 - Optionally, a [`SignedRequestAuth`][signed-request-auth] in the request body

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -6,8 +6,9 @@
   - [Introduction](#introduction)
   - [Constants](#constants)
   - [Bidding](#bidding)
-  - [Per-request Validator Inputs](#per-request-validator-inputs)
+  - [Builder Preferences](#builder-preferences)
     - [`max_trusted_bid`](#max_trusted_bid)
+  - [Per-request Validator Inputs](#per-request-validator-inputs)
   - [Proposer Preferences (Deprecation of Validator Registrations)](#proposer-preferences-deprecation-of-validator-registrations)
   - [Constructing a `SignedExecutionPayloadBid`](#constructing-a-signedexecutionpayloadbid)
   - [Constructing a `SignedExecutionPayloadEnvelope`](#constructing-a-signedexecutionpayloadenvelope)
@@ -75,22 +76,56 @@ def is_eligible_for_bid(
     assert parent_root == hash_tree_root(state.latest_block_header)
 ```
 
+## Builder Preferences
+
+Validators communicate their per-builder preferences ahead of the bid request by
+calling the [`submitBuilderPreferences`][submit-builder-preferences-api] API.
+The builder receives a `SignedBuilderPreferences` object whose `message` contains:
+
+- `max_trusted_bid`: The maximum trusted execution layer payment the proposer
+  will accept from this builder (in Gwei).
+- `builder_pubkey`: The BLS public key of this builder. The builder MUST return
+  a 400 response if this does not match its own identity.
+- `proposer_pubkey`: The BLS public key of the proposer submitting these
+  preferences.
+
+The builder MUST verify the BLS signature against `message.proposer_pubkey`
+before storing the preferences. If verification fails, the builder MUST return a
+400 response.
+
+The builder MUST store the preferences for each proposer and apply the
+`max_trusted_bid` constraint when constructing bids. If no preferences have been
+submitted for a proposer, the builder MUST treat the proposer's `max_trusted_bid`
+as `0`.
+
+### `max_trusted_bid`
+
+`max_trusted_bid` is the maximum value (in Gwei) that a proposer is willing to
+accept as a trusted execution layer payment from this builder. A value of `0`
+indicates that the proposer does not accept any trusted payments from the
+builder, requiring all payments to use the on-chain trustless payments mechanism.
+A value of `MAX_TRUSTED_BID` indicates that the proposer will accept any trusted
+payment amount from the builder. Proposers may adjust this parameter based on
+their level of trust in the builder's reliability and reputation.
+
 ## Per-request Validator Inputs
 
 Validators communicate per-request inputs to a builder on each
 [`getExecutionPayloadBid`][get-execution-payload-bid-api] call:
 
-- The `X-Eth-Max-Trusted-Bid` header carrying a decimal `uint64` (in Gwei) with
-  the proposer's `max_trusted_bid` for this request. This header is
-  **required**.
+- Optionally, the `X-Eth-Max-Trusted-Bid` header carrying a decimal `uint64`
+  (in Gwei) with the proposer's `max_trusted_bid` for this request. MAY be
+  omitted if the proposer has already submitted a `SignedBuilderPreferences`
+  to this builder. If present, it takes precedence over stored
+  `BuilderPreferences` for this request.
 - Optionally, a [`SignedRequestAuth`][signed-request-auth] in the request body
   used to authenticate the requesting validator. The body MAY be encoded as JSON
   (`Content-Type: application/json`) or SSZ
   (`Content-Type: application/octet-stream`); when SSZ is used, the
   `Eth-Consensus-Version` header MUST also be set.
 
-If the `X-Eth-Max-Trusted-Bid` header is missing or malformed, the builder MUST
-NOT serve a bid for the proposer (return a 400 response).
+If neither the `X-Eth-Max-Trusted-Bid` header nor a stored `BuilderPreferences`
+is available for the proposer, the builder MUST treat `max_trusted_bid` as `0`.
 
 If the request body is present, builders MAY verify the `SignedRequestAuth`
 signature against the validator pubkey resolved from the `proposer_index` path
@@ -99,19 +134,6 @@ parameter, and check that `builder_pubkey` matches their own identity and that
 a 400 response.
 
 If the request body is absent, the builder MAY still serve a bid.
-
-### `max_trusted_bid`
-
-`max_trusted_bid` is the maximum value (in Gwei) that a proposer is willing to
-accept as a trusted execution layer payment from this builder for this request.
-A value of `0` indicates that the proposer does not accept any trusted payments
-from the builder, requiring all payments to use the on-chain trustless payments
-mechanism. A value of `MAX_TRUSTED_BID` indicates that the proposer will accept
-any trusted payment amount from the builder. Proposers may adjust this parameter
-based on their level of trust in the builder's reliability and reputation.
-
-`max_trusted_bid` is sent in the clear in the `X-Eth-Max-Trusted-Bid` header and
-is **not** covered by the `RequestAuth` signature.
 
 ## Proposer Preferences (Deprecation of Validator Registrations)
 
@@ -162,6 +184,7 @@ documented in the [Gloas consensus specs][gloas-builder-specs].
 
 [eip-7732]: https://eips.ethereum.org/EIPS/eip-7732
 [get-execution-payload-bid-api]: ./../../apis/builder/execution_payload_bid.yaml
+[submit-builder-preferences-api]: ./../../apis/builder/builder_preferences.yaml
 [gloas-builder-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/builder.md
 [gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
 [proposer-preferences]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -86,15 +86,12 @@ determined from `state.lookahead`. The builder receives a `BuilderPreferencesReq
 - `preferences`: A `BuilderPreferences` with:
   - `max_trusted_bid`: The maximum trusted execution layer payment the proposer
     will accept from this builder (in Gwei).
-  - `builder_pubkey`: The BLS public key of this builder. The builder MUST
-    return a 400 response if this does not match its own identity.
   - `validator_pubkey`: The BLS public key of the validator submitting these
     preferences.
-- `auth`: A `SignedRequestAuth` authenticating the request.
-
-The builder MUST verify the BLS signature in `auth` against
-`preferences.validator_pubkey` before storing the preferences. If verification
-fails, the builder MUST return a 400 response.
+- `auth`: A `SignedRequestAuth` authenticating the request. The builder MUST
+  check that `auth.message.builder_pubkey` matches its own identity and MUST
+  verify the BLS signature against `preferences.validator_pubkey`. If either
+  check fails, the builder MUST return a 400 response.
 
 The builder MUST store the preferences for each proposer and apply the
 `max_trusted_bid` constraint when constructing bids. If no preferences have been

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -80,11 +80,11 @@ class SignedBuilderPreferences(Container):
 
 ## Submitting Builder Preferences
 
-Before requesting a bid, the validator SHOULD submit its
+Based on the proposer lookahead, the validator SHOULD submit its
 [`SignedBuilderPreferences`](#signedbuilderpreferences) to each builder via the
-[`submitBuilderPreferences`][submit-builder-preferences-api] API call. This
-communicates the proposer's `max_trusted_bid` to the builder ahead of the bid
-request.
+[`submitBuilderPreferences`][submit-builder-preferences-api] API call an epoch
+prior to the proposing epoch. This ensures builders have the preferences before
+the bid request arrives.
 
 The validator constructs a `BuilderPreferences` with:
 
@@ -115,11 +115,11 @@ level of trust in the builder's reliability and reputation.
 The validator MAY also send `max_trusted_bid` as a decimal `uint64` in the
 `X-Eth-Max-Trusted-Bid` header on a
 [`getExecutionPayloadBid`][get-execution-payload-bid-api] request, for example
-if `BuilderPreferences` have not been submitted to this builder. If sent, the
-header takes precedence over stored `BuilderPreferences` for that request. Note
-that `max_trusted_bid` is **not** covered by the `RequestAuth` signature. The
-validator MUST remember the effective `max_trusted_bid` for each request so it
-can validate the resulting bid against the same value.
+if `BuilderPreferences` have not been submitted to this builder. If a
+`BuilderPreferences` has been submitted, it takes precedence over the header.
+Note that `max_trusted_bid` is **not** covered by the `RequestAuth` signature.
+The validator MUST remember the effective `max_trusted_bid` for each request so
+it can validate the resulting bid against the same value.
 
 ## Bid Request
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -66,7 +66,6 @@ specific builder ahead of the bid request.
 ```python
 class BuilderPreferences(Container):
     max_trusted_bid: Gwei
-    builder_pubkey: BLSPubkey
     validator_pubkey: BLSPubkey
 ```
 
@@ -91,16 +90,15 @@ The validator constructs a `BuilderPreferences` with:
 
 - `max_trusted_bid`: The maximum trusted execution layer payment the proposer
   will accept from this builder. See [`max_trusted_bid`](#max_trusted_bid).
-- `builder_pubkey`: The BLS public key of the builder these preferences are
-  intended for.
 - `validator_pubkey`: The validator's own BLS public key.
 
 The validator then constructs a `BuilderPreferencesRequest` with the
 `BuilderPreferences` as `preferences` and a `SignedRequestAuth` as `auth`. The
 `SignedRequestAuth` is constructed as described in
-[Constructing the `RequestAuth`](#constructing-the-requestauth). The builder
-MUST verify the `auth` signature against `preferences.validator_pubkey` and MUST
-reject the request with a 400 response if `preferences.builder_pubkey` does not
+[Constructing the `RequestAuth`](#constructing-the-requestauth); its
+`auth.message.builder_pubkey` identifies the intended builder. The builder MUST
+verify the `auth` signature against `preferences.validator_pubkey` and MUST
+reject the request with a 400 response if `auth.message.builder_pubkey` does not
 match its own identity.
 
 If no preferences have been submitted, the builder MUST treat the proposer's

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -66,7 +66,6 @@ specific builder ahead of the bid request.
 ```python
 class BuilderPreferences(Container):
     max_trusted_bid: Gwei
-    validator_pubkey: BLSPubkey
 ```
 
 #### `BuilderPreferencesRequest`
@@ -90,14 +89,16 @@ The validator constructs a `BuilderPreferences` with:
 
 - `max_trusted_bid`: The maximum trusted execution layer payment the proposer
   will accept from this builder. See [`max_trusted_bid`](#max_trusted_bid).
-- `validator_pubkey`: The validator's own BLS public key.
+
+The validator's BLS public key is passed as the `validator_pubkey` path parameter
+in the [`submitBuilderPreferences`][submit-builder-preferences-api] API call.
 
 The validator then constructs a `BuilderPreferencesRequest` with the
 `BuilderPreferences` as `preferences` and a `SignedRequestAuth` as `auth`. The
 `SignedRequestAuth` is constructed as described in
 [Constructing the `RequestAuth`](#constructing-the-requestauth); its
 `auth.message.builder_pubkey` identifies the intended builder. The builder MUST
-verify the `auth` signature against `preferences.validator_pubkey` and MUST
+verify the `auth` signature against the `validator_pubkey` path parameter and MUST
 reject the request with a 400 response if `auth.message.builder_pubkey` does not
 match its own identity.
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -8,9 +8,12 @@
     - [New Containers](#new-containers)
       - [`RequestAuth`](#requestauth)
       - [`SignedRequestAuth`](#signedrequestauth)
+      - [`BuilderPreferences`](#builderpreferences)
+      - [`SignedBuilderPreferences`](#signedbuilderpreferences)
+  - [Submitting Builder Preferences](#submitting-builder-preferences)
+    - [`max_trusted_bid`](#max_trusted_bid)
   - [Bid Request](#bid-request)
     - [Constructing the `RequestAuth`](#constructing-the-requestauth)
-    - [`max_trusted_bid`](#max_trusted_bid)
   - [Proposer Preferences](#proposer-preferences)
   - [Validating a `SignedExecutionPayloadBid`](#validating-a-signedexecutionpayloadbid)
   - [Block proposal](#block-proposal)
@@ -55,13 +58,78 @@ class SignedRequestAuth(Container):
     signature: BLSSignature
 ```
 
+#### `BuilderPreferences`
+
+`BuilderPreferences` communicates a proposer's per-builder preferences to a
+specific builder ahead of the bid request.
+
+```python
+class BuilderPreferences(Container):
+    max_trusted_bid: Gwei
+    builder_pubkey: BLSPubkey
+    proposer_pubkey: BLSPubkey
+```
+
+#### `SignedBuilderPreferences`
+
+```python
+class SignedBuilderPreferences(Container):
+    message: BuilderPreferences
+    signature: BLSSignature
+```
+
+## Submitting Builder Preferences
+
+Before requesting a bid, the validator SHOULD submit its
+[`SignedBuilderPreferences`](#signedbuilderpreferences) to each builder via the
+[`submitBuilderPreferences`][submit-builder-preferences-api] API call. This
+communicates the proposer's `max_trusted_bid` to the builder ahead of the bid
+request.
+
+The validator constructs a `BuilderPreferences` with:
+
+- `max_trusted_bid`: The maximum trusted execution layer payment the proposer
+  will accept from this builder. See [`max_trusted_bid`](#max_trusted_bid).
+- `builder_pubkey`: The BLS public key of the builder these preferences are
+  intended for.
+- `proposer_pubkey`: The validator's own BLS public key.
+
+The validator then signs the `BuilderPreferences` to produce a
+`SignedBuilderPreferences` and submits it to the builder. The builder MUST
+verify the signature against `proposer_pubkey` and MUST reject the request with
+a 400 response if `builder_pubkey` does not match its own identity.
+
+If no preferences have been submitted, the builder MUST treat the proposer's
+`max_trusted_bid` as `0`.
+
+### `max_trusted_bid`
+
+`max_trusted_bid` is the maximum value (in Gwei) that the proposer is willing to
+accept as a trusted execution layer payment from this builder. A value of `0`
+means the proposer does not accept any trusted payments from this builder,
+requiring all payments to go through the on-chain trustless payments mechanism.
+A value of `MAX_TRUSTED_BID` means the proposer will accept any trusted payment
+amount from the builder. Proposers may adjust this parameter based on their
+level of trust in the builder's reliability and reputation.
+
+The validator MAY also send `max_trusted_bid` as a decimal `uint64` in the
+`X-Eth-Max-Trusted-Bid` header on a
+[`getExecutionPayloadBid`][get-execution-payload-bid-api] request, for example
+if `BuilderPreferences` have not been submitted to this builder. If sent, the
+header takes precedence over stored `BuilderPreferences` for that request. Note
+that `max_trusted_bid` is **not** covered by the `RequestAuth` signature. The
+validator MUST remember the effective `max_trusted_bid` for each request so it
+can validate the resulting bid against the same value.
+
 ## Bid Request
 
 When calling [`getExecutionPayloadBid`][get-execution-payload-bid-api], the
-validator MUST send the `X-Eth-Max-Trusted-Bid` header carrying a decimal
-`uint64` (in Gwei) expressing the per-builder `max_trusted_bid` for this
-request. See [`max_trusted_bid`](#max_trusted_bid). If the header is missing,
-the builder will not serve a bid for the proposer.
+validator MAY send the `X-Eth-Max-Trusted-Bid` header carrying a decimal
+`uint64` (in Gwei) expressing the per-request `max_trusted_bid`. This header
+MAY be omitted if the validator has already submitted a
+[`SignedBuilderPreferences`](#signedbuilderpreferences) to this builder. If the
+header is present, it takes precedence over the stored `BuilderPreferences` for
+this request.
 
 The validator MAY additionally send a [`SignedRequestAuth`](#signedrequestauth)
 as the request body to authenticate the request. The body MAY be encoded as JSON
@@ -88,22 +156,6 @@ The validator then constructs the `SignedRequestAuth` by signing the
 [`getExecutionPayloadBid`][get-execution-payload-bid-api] request. The signature
 lets builders authenticate the requesting validator and discard requests from
 other parties (e.g. DDOS or replay attempts from competing builders).
-
-### `max_trusted_bid`
-
-`max_trusted_bid` is the maximum value (in Gwei) that the proposer is willing to
-accept as a trusted execution layer payment from this builder for this request.
-A value of `0` means the proposer does not accept any trusted payments from this
-builder, requiring all payments to go through the on-chain trustless payments
-mechanism. A value of `MAX_TRUSTED_BID` means the proposer will accept any
-trusted payment amount from the builder. Proposers may adjust this parameter
-based on their level of trust in the builder's reliability and reputation.
-
-The validator sends `max_trusted_bid` as a decimal `uint64` in the
-`X-Eth-Max-Trusted-Bid` header. Note that `max_trusted_bid` is **not** covered
-by the `RequestAuth` signature. The validator MUST remember the
-`max_trusted_bid` value it sent for each request so it can validate the
-resulting bid against the same value.
 
 ## Proposer Preferences
 
@@ -187,8 +239,9 @@ block on top of a beacon `state` must take the following actions:
 1. Call upstream builder software to get a
    [`SignedExecutionPayloadBid`][signed-execution-payload-bid] using the
    [`getExecutionPayloadBid`][get-execution-payload-bid-api] API call. The
-   validator MUST include the `X-Eth-Max-Trusted-Bid` header on the request;
-   otherwise the builder will not serve a bid. The validator MAY additionally
+   validator MAY include the `X-Eth-Max-Trusted-Bid` header on the request if
+   `BuilderPreferences` have not been previously submitted to this builder. The
+   validator MAY additionally
    send a `SignedRequestAuth` in the request body to authenticate the request.
 2. Assemble a `SignedBeaconBlock` according to the process outlined in the
    [Gloas validator specs][gloas-validator-specs] but with the best
@@ -203,6 +256,7 @@ block on top of a beacon `state` must take the following actions:
 
 [can-builder-cover-bid]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#can_builder_cover_bid
 [get-execution-payload-bid-api]: ./../../apis/builder/execution_payload_bid.yaml
+[submit-builder-preferences-api]: ./../../apis/builder/builder_preferences.yaml
 [gloas-consensus-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas
 [gloas-validator-specs]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/validator.md#block-proposal
 [is-active-builder]: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#is_active_builder

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -9,7 +9,7 @@
       - [`RequestAuth`](#requestauth)
       - [`SignedRequestAuth`](#signedrequestauth)
       - [`BuilderPreferences`](#builderpreferences)
-      - [`SignedBuilderPreferences`](#signedbuilderpreferences)
+      - [`BuilderPreferencesRequest`](#builderpreferencesrequest)
   - [Submitting Builder Preferences](#submitting-builder-preferences)
     - [`max_trusted_bid`](#max_trusted_bid)
   - [Bid Request](#bid-request)
@@ -67,22 +67,22 @@ specific builder ahead of the bid request.
 class BuilderPreferences(Container):
     max_trusted_bid: Gwei
     builder_pubkey: BLSPubkey
-    proposer_pubkey: BLSPubkey
+    validator_pubkey: BLSPubkey
 ```
 
-#### `SignedBuilderPreferences`
+#### `BuilderPreferencesRequest`
 
 ```python
-class SignedBuilderPreferences(Container):
-    message: BuilderPreferences
-    signature: BLSSignature
+class BuilderPreferencesRequest(Container):
+    preferences: BuilderPreferences
+    auth: SignedRequestAuth
 ```
 
 ## Submitting Builder Preferences
 
-The validator SHOULD submit its
-[`SignedBuilderPreferences`](#signedbuilderpreferences) to each builder via the
-[`submitBuilderPreferences`][submit-builder-preferences-api] API call in the
+The validator MAY submit its
+[`BuilderPreferencesRequest`](#builderpreferencesrequest) to each builder via
+the [`submitBuilderPreferences`][submit-builder-preferences-api] API call in the
 epoch prior to the epoch in which they will be proposing, as determined from
 `state.lookahead`. This ensures builders have the preferences before the bid
 request arrives.
@@ -93,12 +93,15 @@ The validator constructs a `BuilderPreferences` with:
   will accept from this builder. See [`max_trusted_bid`](#max_trusted_bid).
 - `builder_pubkey`: The BLS public key of the builder these preferences are
   intended for.
-- `proposer_pubkey`: The validator's own BLS public key.
+- `validator_pubkey`: The validator's own BLS public key.
 
-The validator then signs the `BuilderPreferences` to produce a
-`SignedBuilderPreferences` and submits it to the builder. The builder MUST
-verify the signature against `proposer_pubkey` and MUST reject the request with
-a 400 response if `builder_pubkey` does not match its own identity.
+The validator then constructs a `BuilderPreferencesRequest` with the
+`BuilderPreferences` as `preferences` and a `SignedRequestAuth` as `auth`. The
+`SignedRequestAuth` is constructed as described in
+[Constructing the `RequestAuth`](#constructing-the-requestauth). The builder
+MUST verify the `auth` signature against `preferences.validator_pubkey` and MUST
+reject the request with a 400 response if `preferences.builder_pubkey` does not
+match its own identity.
 
 If no preferences have been submitted, the builder MUST treat the proposer's
 `max_trusted_bid` as `0`.
@@ -128,7 +131,7 @@ When calling [`getExecutionPayloadBid`][get-execution-payload-bid-api], the
 validator MAY send the `X-Eth-Max-Trusted-Bid` header carrying a decimal
 `uint64` (in Gwei) expressing the per-request `max_trusted_bid`. This header
 MAY be omitted if the validator has already submitted a
-[`SignedBuilderPreferences`](#signedbuilderpreferences) to this builder. If the
+[`BuilderPreferencesRequest`](#builderpreferencesrequest) to this builder. If the
 header is present, it takes precedence over the stored `BuilderPreferences` for
 this request.
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -80,11 +80,12 @@ class SignedBuilderPreferences(Container):
 
 ## Submitting Builder Preferences
 
-Based on the proposer lookahead, the validator SHOULD submit its
+The validator SHOULD submit its
 [`SignedBuilderPreferences`](#signedbuilderpreferences) to each builder via the
-[`submitBuilderPreferences`][submit-builder-preferences-api] API call an epoch
-prior to the proposing epoch. This ensures builders have the preferences before
-the bid request arrives.
+[`submitBuilderPreferences`][submit-builder-preferences-api] API call in the
+epoch prior to the epoch in which they will be proposing, as determined from
+`state.lookahead`. This ensures builders have the preferences before the bid
+request arrives.
 
 The validator constructs a `BuilderPreferences` with:
 

--- a/types/gloas/builder_preferences.yaml
+++ b/types/gloas/builder_preferences.yaml
@@ -2,14 +2,11 @@ Gloas:
   BuilderPreferences:
     type: object
     description: "Per-builder preferences that a proposer can express."
-    required: [max_trusted_bid, validator_pubkey]
+    required: [max_trusted_bid]
     properties:
       max_trusted_bid:
         $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
         description: "Indicates the maximum amount that a proposer is willing to accept as a trusted payment amount from the builder."
-      validator_pubkey:
-        $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
-        description: "The BLS public key of the validator expressing these preferences."
   BuilderPreferencesRequest:
     type: object
     description: "A builder preferences submission containing the proposer's preferences and a signed request authentication."

--- a/types/gloas/builder_preferences.yaml
+++ b/types/gloas/builder_preferences.yaml
@@ -2,7 +2,7 @@ Gloas:
   BuilderPreferences:
     type: object
     description: "Per-builder preferences that a proposer can express."
-    required: [max_trusted_bid, builder_pubkey, proposer_pubkey]
+    required: [max_trusted_bid, builder_pubkey, validator_pubkey]
     properties:
       max_trusted_bid:
         $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
@@ -10,15 +10,15 @@ Gloas:
       builder_pubkey:
         $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
         description: "The BLS public key of the builder these preferences are intended for."
-      proposer_pubkey:
+      validator_pubkey:
         $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
-        description: "The BLS public key of the proposer expressing these preferences."
-  SignedBuilderPreferences:
+        description: "The BLS public key of the validator expressing these preferences."
+  BuilderPreferencesRequest:
     type: object
-    description: "A signed `BuilderPreferences` message."
-    required: [message, signature]
+    description: "A builder preferences submission containing the proposer's preferences and a signed request authentication."
+    required: [preferences, auth]
     properties:
-      message:
+      preferences:
         $ref: "#/Gloas/BuilderPreferences"
-      signature:
-        $ref: "../../beacon-apis/types/primitive.yaml#/Signature"
+      auth:
+        $ref: "./request_auth.yaml#/Gloas/SignedRequestAuth"

--- a/types/gloas/builder_preferences.yaml
+++ b/types/gloas/builder_preferences.yaml
@@ -13,3 +13,12 @@ Gloas:
       proposer_pubkey:
         $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
         description: "The BLS public key of the proposer expressing these preferences."
+  SignedBuilderPreferences:
+    type: object
+    description: "A signed `BuilderPreferences` message."
+    required: [message, signature]
+    properties:
+      message:
+        $ref: "#/Gloas/BuilderPreferences"
+      signature:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Signature"

--- a/types/gloas/builder_preferences.yaml
+++ b/types/gloas/builder_preferences.yaml
@@ -2,14 +2,11 @@ Gloas:
   BuilderPreferences:
     type: object
     description: "Per-builder preferences that a proposer can express."
-    required: [max_trusted_bid, builder_pubkey, validator_pubkey]
+    required: [max_trusted_bid, validator_pubkey]
     properties:
       max_trusted_bid:
         $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
         description: "Indicates the maximum amount that a proposer is willing to accept as a trusted payment amount from the builder."
-      builder_pubkey:
-        $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
-        description: "The BLS public key of the builder these preferences are intended for."
       validator_pubkey:
         $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
         description: "The BLS public key of the validator expressing these preferences."

--- a/types/gloas/builder_preferences.yaml
+++ b/types/gloas/builder_preferences.yaml
@@ -1,0 +1,15 @@
+Gloas:
+  BuilderPreferences:
+    type: object
+    description: "Per-builder preferences that a proposer can express."
+    required: [max_trusted_bid, builder_pubkey, proposer_pubkey]
+    properties:
+      max_trusted_bid:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Uint64"
+        description: "Indicates the maximum amount that a proposer is willing to accept as a trusted payment amount from the builder."
+      builder_pubkey:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
+        description: "The BLS public key of the builder these preferences are intended for."
+      proposer_pubkey:
+        $ref: "../../beacon-apis/types/primitive.yaml#/Pubkey"
+        description: "The BLS public key of the proposer expressing these preferences."


### PR DESCRIPTION
# Endpoint to submit builder preferences (Gloas)

## Summary

Introduces a new `POST /eth/v1/builder/builder_preferences` endpoint for the
Gloas fork that allows validators to submit per-builder preferences to a builder
ahead of the bid request. This replaces the `X-Eth-Max-Trusted-Bid` request
header as the primary channel for communicating `max_trusted_bid`, while keeping
the header as an optional fallback.

## New types

**`BuilderPreferences`** (`types/gloas/builder_preferences.yaml`)
```python
class BuilderPreferences(Container):
    max_trusted_bid: Gwei
    validator_pubkey: BLSPubkey
```

**`BuilderPreferencesRequest`** — the request body for the new endpoint:
```python
class BuilderPreferencesRequest(Container):
    preferences: BuilderPreferences
    auth: SignedRequestAuth
```

Authentication reuses the existing `SignedRequestAuth` mechanism. The builder
checks that `auth.message.builder_pubkey` matches its own identity and verifies
the BLS signature against `preferences.validator_pubkey`.

## New endpoint

`POST /eth/v1/builder/builder_preferences`

- Validators MAY call this endpoint in the epoch prior to the epoch in which
  they will be proposing, as determined from `state.lookahead`.
- The builder stores the preferences per-validator and uses the `max_trusted_bid`
  when constructing bids.
- `max_trusted_bid` resolution order on `getExecutionPayloadBid`:
  1. Stored `BuilderPreferences` (submitted via this endpoint).
  2. `X-Eth-Max-Trusted-Bid` header, if present and no preferences stored.
  3. `0`, if neither is available.

## Changes to `getExecutionPayloadBid`

- `X-Eth-Max-Trusted-Bid` is now **optional** (`required: false`). Validators
  MAY send it if they have not submitted `BuilderPreferences` to this builder.
- If stored `BuilderPreferences` exist for the proposer, they take precedence
  over the header.
- Removed the `MissingMaxTrustedBid` 400 error example.

## Spec updates

- `specs/gloas/validator.md`: New `BuilderPreferences` and
  `BuilderPreferencesRequest` containers; new _Submitting Builder Preferences_
  section describing when and how to call the endpoint; updated _Bid Request_
  section to reflect the optional header; updated `validate_bid` note.
- `specs/gloas/builder.md`: New _Builder Preferences_ section describing
  storage, precedence rules, and signature verification; updated _Per-request
  Validator Inputs_ to reflect the optional header.
